### PR TITLE
[keepercore] CLI Genesis

### DIFF
--- a/keepercore/.gitignore
+++ b/keepercore/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 
 # IDE
 .idea
+.swp

--- a/keepercore/core/__main__.py
+++ b/keepercore/core/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from argparse import ArgumentParser, Namespace
 
 from aiohttp import web
@@ -32,7 +33,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--plantuml-server",
         default="https://www.plantuml.com/plantuml",
-        help="The plantuml server to use to render plantuml images",
+        help="The plantuml server to render plantuml images",
     )
     return parser.parse_args()
 
@@ -52,7 +53,7 @@ def main() -> None:
     db = DbAccess(database, event_bus)
     model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
     cli_deps = CLIDependencies(event_bus, db, model)
-    cli = CLI(cli_deps, all_parts(cli_deps))
+    cli = CLI(cli_deps, all_parts(cli_deps), dict(os.environ))
 
     subscriptions = SubscriptionHandler()
     workflow_handler = WorkflowHandler(event_bus, subscriptions, scheduler)

--- a/keepercore/core/__main__.py
+++ b/keepercore/core/__main__.py
@@ -8,7 +8,7 @@ from arango import ArangoClient
 from core.db.arangodb_extensions import ArangoHTTPClient
 from core.db.db_access import DbAccess
 from core.event_bus import EventBus
-from core.model.model_handler import ModelHandler
+from core.model.model_handler import ModelHandlerDB
 from core.web.api import Api
 from core.workflow.scheduler import Scheduler
 from core.workflow.subscribers import SubscriptionHandler
@@ -48,7 +48,7 @@ def main() -> None:
     client = ArangoClient(hosts=args.arango_server, http_client=http_client)
     database = client.db(args.arango_database, username=args.arango_username, password=args.arango_password)
     db = DbAccess(database, event_bus)
-    model = ModelHandler(db.get_model_db(), args.plantuml_server)
+    model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
 
     subscriptions = SubscriptionHandler()
     workflow_handler = WorkflowHandler(event_bus, subscriptions, scheduler)

--- a/keepercore/core/cli/cli.py
+++ b/keepercore/core/cli/cli.py
@@ -142,6 +142,7 @@ class HelpCommand(CLISource):
             available = "\n".join(f"   {part.name} - {part.info()}" for part in parts)
             replacements = "\n".join(f"   @{key}@ -> {value}" for key, value in CLI.replacements().items())
             result = (
+                f"\nkeepercore CLI\n\n\n"
                 f"Valid placeholder string:\n{replacements}\n\n"
                 f"Available Commands:\n{available}\n\n"
                 f"Note that you can pipe commands using the pipe character (|)\n"

--- a/keepercore/core/cli/cli.py
+++ b/keepercore/core/cli/cli.py
@@ -25,15 +25,11 @@ from core.event_bus import EventBus
 from core.model.model_handler import ModelHandler
 from core.parse_util import make_parser, literal_dp, equals_dp, value_dp, space_dp
 from core.types import JsonElement
-from core.util import identity, split_esc, utc_str, utc
+from core.util import split_esc, utc_str, utc
 
 T = TypeVar("T")
 # Allow the function to return either a coroutine or the result directly
 Result = Union[T, Coroutine[Any, Any, T]]
-# A flow function receives a t
-# When a t is returned, it will be passed to the next function
-# If None is returned, the value is discarded
-FlowFunction = Callable[[T], Result[Optional[T]]]
 # A source provides a stream of objects
 Source = AsyncGenerator[JsonElement, None]
 # Every Command will return a function that takes a stream and returns a stream of objects.
@@ -103,18 +99,7 @@ class CLICommand(CLIPart, ABC):
     """
 
     async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
-        single_function = await self.process_single(arg)
-        return self.flow_from_function(single_function)
-
-    async def process_single(self, arg: Optional[str] = None) -> FlowFunction[JsonElement]:
-        return identity
-
-    @staticmethod
-    def flow_from_function(fn: FlowFunction[JsonElement]) -> Flow:
-        def process(content: Stream) -> AsyncGenerator[JsonElement, None]:
-            return stream.filter(stream.map(content, fn), lambda x: x is not None)  # type: ignore
-
-        return process
+        pass
 
 
 class CLISink(CLIPart):

--- a/keepercore/core/cli/cli.py
+++ b/keepercore/core/cli/cli.py
@@ -1,0 +1,204 @@
+import asyncio
+import inspect
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, Union, Callable, TypeVar, Any, Coroutine, List, AsyncGenerator, Tuple, Dict
+
+from aiostream import stream
+from aiostream.core import Stream
+
+from core.db.db_access import DbAccess
+from core.error import CLIParseError
+from core.event_bus import EventBus
+from core.model.model_handler import ModelHandler
+from core.types import Json
+from core.util import identity, split_esc
+
+T = TypeVar("T")
+# Allow the function to return either a coroutine or the result directly
+Result = Union[T, Coroutine[Any, Any, T]]
+# A flow function receives a t
+# When a t is returned, it will be passed to the next function
+# If None is returned, the value is discarded
+FlowFunction = Callable[[T], Result[Optional[T]]]
+# A source provides a stream of objects
+Source = AsyncGenerator[Json, None]
+# Every Command will return a function that takes a stream and returns a stream of objects.
+Flow = Callable[[Stream], AsyncGenerator[Json, None]]
+# A sink function takes a stream and creates a result
+Sink = Callable[[Stream], Coroutine[Any, Any, T]]
+
+
+@dataclass(frozen=True)
+class CLIDependencies:
+    event_bus: EventBus
+    db_access: DbAccess
+    model_handler: ModelHandler
+
+
+class CLIPart(ABC):
+    """
+    The CLIPart is the base for all participants of the cli execution.
+    Source: generates a stream of objects
+    Flow: transforms the elements in a stream of objects
+    Sink: takes a stream of objects and creates a result
+    """
+
+    def __init__(self, dependencies: CLIDependencies):
+        self.dependencies = dependencies
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    def help(self) -> str:
+        # if not defined in subclass, fallback to inline doc
+        doc = inspect.getdoc(type(self))
+        return doc if doc else f"{self.name}: no help available."
+
+    async def parse(self, arg: Optional[str], **env: str) -> Union[Source, Flow, Sink[Any]]:
+        pass
+
+
+class CLISource(CLIPart):
+    """
+    Subclasses of CLISource can create a stream.
+    """
+
+    @abstractmethod
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
+        pass
+
+    @staticmethod
+    async def empty() -> Source:
+        for _ in range(0, 0):
+            yield {}
+
+
+class CLICommand(CLIPart, ABC):
+    """
+    Subclasses of CLICommand can transform the incoming stream into another stream and
+    eventually performing a side effect.
+
+    Simple CLICommands can simply override the process_single method.
+    If a CLICommand wants to interact with the stream directly, tbe parse method has to be overridden.
+    """
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        single_function = await self.process_single(arg)
+        return self.flow_from_function(single_function)
+
+    async def process_single(self, arg: Optional[str] = None) -> FlowFunction[Json]:
+        return identity
+
+    @staticmethod
+    def flow_from_function(fn: FlowFunction[Json]) -> Flow:
+        def process(content: Stream) -> AsyncGenerator[Json, None]:
+            return stream.filter(stream.map(content, fn), lambda x: x is not None)  # type: ignore
+
+        return process
+
+
+class CLISink(CLIPart):
+    """
+    Subclasses of a sink transform the incoming stream into a result.
+    Most useful sinks:
+    - ConsoleSink: prints to stdout and returns None
+    - ListSink: collects all elements and returns the final list
+    """
+
+    @abstractmethod
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Sink[Any]:
+        pass
+
+
+class HelpCommand(CLISource):
+    """
+    Usage: help <command>
+
+    Show help text for a command.
+    """
+
+    def __init__(self, dependencies: CLIDependencies, parts: List[CLIPart]):
+        super().__init__(dependencies)
+        self.parts: Dict[str, CLIPart] = {p.name: p for p in parts + [self]}
+
+    @property
+    def name(self) -> str:
+        return "help"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
+        if not arg:
+            available = "\n".join(f" -{cmd}" for cmd in self.parts.keys())
+            result = (
+                f"{self.help()}\n\nAvailable Commands:\n{available}\n\n"
+                f"Note that you can pipe commands using the pipe character (|)\n"
+                f"and chain multiple commands using the semicolon (;)."
+            )
+        elif arg and arg in self.parts:
+            cmd = self.parts[arg]
+            result = cmd.help()
+        else:
+            result = f"No command found with this name: {arg}"
+
+        return stream.just(result)  # type: ignore
+
+
+@dataclass
+class ParsedCommandLine:
+    parts: List[CLIPart]
+    generator: AsyncGenerator[Json, None]
+
+
+class CLI:
+    def __init__(self, dependencies: CLIDependencies, parts: List[CLIPart]):
+        help_cmd = HelpCommand(dependencies, parts)
+        self.parts = {p.name: p for p in parts + [help_cmd]}
+
+    async def evaluate_cli_command(self, cli_input: str, **env: str) -> List[ParsedCommandLine]:
+        def parse_single_command(index: int, command: str) -> Tuple[CLIPart, str]:
+            expected = CLISource if index == 0 else CLICommand
+            p = command.strip().split(" ", 1)
+            part_str, args_str = (p[0], p[1]) if len(p) == 2 else (p[0], "")
+            if part_str in self.parts:
+                part: CLIPart = self.parts[part_str]
+                if isinstance(part, expected):
+                    return part, args_str
+                else:
+                    detail = "no source data given" if index == 0 else "must be the first command"
+                    raise CLIParseError(f"Command >{part_str}< can not be used in this position: {detail}")
+            else:
+                raise CLIParseError(f"Command >{part_str}< is not known. typo?")
+
+        async def parse_arg(part: CLIPart, args_str: str) -> Any:
+            try:
+                fn = part.parse(args_str, **env)
+                return await fn if asyncio.iscoroutine(fn) else fn
+            except Exception as ex:
+                kind = type(ex).__name__
+                raise CLIParseError(f"{part.name}: can not parse: {args_str}: {kind}: {str(ex)}") from ex
+
+        async def parse_line(line: str) -> ParsedCommandLine:
+            parts_with_args = [parse_single_command(idx, cmd) for idx, cmd in enumerate(split_esc(line, "|"))]
+            parts = [part for part, _ in parts_with_args]
+            if parts_with_args:
+                source, source_arg = parts_with_args[0]
+                flow = await parse_arg(source, source_arg)
+                flow = flow if isinstance(flow, Stream) else stream.iterate(flow)
+                for command, arg in parts_with_args[1:]:
+                    flow_fn: Flow = await parse_arg(command, arg)
+                    flow = flow_fn(flow)
+                    flow = flow if isinstance(flow, Stream) else stream.iterate(flow)
+                return ParsedCommandLine(parts, flow)
+            else:
+                return ParsedCommandLine([], CLISource.empty())
+
+        return [await parse_line(cmd_line) for cmd_line in split_esc(cli_input, ";")]
+
+    async def execute_cli_command(self, cli_input: str, sink: Sink[T], **env: str) -> List[T]:
+        results: List[T] = []
+        for parsed in await self.evaluate_cli_command(cli_input, **env):
+            to_sink = sink(parsed.generator)
+            results.append(await to_sink)
+        return results

--- a/keepercore/core/cli/cli.py
+++ b/keepercore/core/cli/cli.py
@@ -232,7 +232,8 @@ class CLI:
                 for command, arg in parts_with_args[1:]:
                     flow_fn: Flow = await parse_arg(command, arg, **resulting_env)
                     flow = make_stream(flow_fn(flow))
-                return ParsedCommandLine(resulting_env, parts, flow)  # type: ignore
+                # noinspection PyTypeChecker
+                return ParsedCommandLine(resulting_env, parts, flow)
             else:
                 return ParsedCommandLine(resulting_env, [], CLISource.empty())
 

--- a/keepercore/core/cli/command.py
+++ b/keepercore/core/cli/command.py
@@ -1,0 +1,222 @@
+import json
+from abc import abstractmethod, ABC
+from functools import partial
+from typing import List, Optional, Any, Tuple, AsyncGenerator, Union, Hashable
+
+from aiostream import stream
+from aiostream.core import Stream
+from parsy import Parser
+
+from core.cli.cli import CLISource, CLISink, Sink, Source, CLICommand, Flow, CLIDependencies, CLIPart
+from core.db.model import QueryModel
+from core.error import CLIParseError
+from core.query.query_parser import parse_query, value_p, equals_p, literal_p, comma_p
+from core.types import Json
+from core.util import make_parser
+
+
+class EchoSource(CLISource):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
+        js = json.loads(arg if arg else "")
+        if isinstance(js, list):
+            elements = js
+        elif isinstance(js, (str, int, float, bool, dict)):
+            elements = [js]
+        else:
+            raise AttributeError(f"Echo does not understand {arg}.")
+
+        for element in elements:
+            yield element
+
+
+class MatchSource(CLISource):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "match"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
+        # db name and section is coming from the env
+        db_name = env["graphdb"]
+        query_section = env.get("section", "reported")
+        if not arg:
+            raise CLIParseError("match command needs a query to execute, but nothing was given!")
+        query = parse_query(arg)
+        model = await self.dependencies.model_handler.load_model()
+        db = self.dependencies.db_access.get_graph_db(db_name)
+        return db.query_list(QueryModel(query, model, query_section), with_system_props=True)
+
+
+class CountCommand(CLICommand):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "count"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        def inc_prop(o: Any) -> Tuple[int, int]:
+            def prop_value() -> Tuple[int, int]:
+                try:
+                    return int(o[arg]), 0
+                except Exception:
+                    return 0, 1
+
+            return prop_value() if arg in o else (0, 1)
+
+        def inc_identity(_: Any) -> Tuple[int, int]:
+            return 1, 0
+
+        fn = inc_prop if arg else inc_identity
+
+        async def count_in_stream(content: Stream) -> AsyncGenerator[Json, None]:
+            counter = 0
+            no_match = 0
+
+            async with content.stream() as in_stream:
+                async for element in in_stream:
+                    cnt, not_matched = fn(element)
+                    counter += cnt
+                    no_match += not_matched
+            yield {"matched": counter, "not_matched": no_match}
+
+        return count_in_stream
+
+
+class ChunkCommand(CLICommand):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "chunk"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        size = int(arg) if arg else 100
+        return lambda in_stream: stream.chunks(in_stream, size)
+
+
+class FlattenCommand(CLICommand):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "flatten"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        return lambda in_stream: stream.flatmap(in_stream, stream.iterate)
+
+
+class UniqCommand(CLICommand):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "uniq"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        visited = set()
+
+        def hashed(item: Any) -> Hashable:
+            if isinstance(item, dict):
+                return json.dumps(item, sort_keys=True)
+            else:
+                raise CLIParseError(f"{self.name} can not make {item}:{type(item)} uniq")
+
+        def has_not_seen(item: Any) -> bool:
+            item = item if isinstance(item, Hashable) else hashed(item)
+
+            if item in visited:
+                return False
+            else:
+                visited.add(item)
+                return True
+
+        return lambda in_stream: stream.filter(in_stream, has_not_seen)
+
+
+class SetDesiredState(CLICommand, ABC):  # type: ignore
+    @abstractmethod
+    def patch(self, arg: Optional[str] = None, **env: str) -> Json:
+        # deriving classes need to define how to patch
+        pass
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Flow:
+        buffer_size = 1000
+        result_section = env["result_section"].split(",") if "result_section" in env else ["reported", "desired"]
+        func = partial(self.set_desired, env["graphdb"], self.patch(arg, **env), result_section)
+        return lambda in_stream: stream.flatmap(stream.chunks(in_stream, buffer_size), func)
+
+    async def set_desired(
+        self, graph_name: str, patch: Json, result_section: Union[str, List[str]], items: List[Json]
+    ) -> AsyncGenerator[Json, None]:
+        db = self.dependencies.db_access.get_graph_db(graph_name)
+        node_ids = [a["_id"] for a in items if "_id" in a]
+        async for update in db.update_nodes_desired(patch, node_ids, result_section):
+            yield update
+
+
+@make_parser
+def key_value_parser() -> Parser:
+    key = yield literal_p
+    yield equals_p
+    value = yield value_p
+    return key, value
+
+
+key_values_parser = key_value_parser.sep_by(comma_p).map(dict)
+
+
+class DesireCommand(SetDesiredState):
+    @property
+    def name(self) -> str:
+        return "desire"
+
+    def patch(self, arg: Optional[str] = None, **env: str) -> Json:
+        if arg and arg.strip():
+            return key_values_parser.parse(arg)  # type: ignore
+        else:
+            return {}
+
+
+class MarkDeleteCommand(SetDesiredState):
+    @property
+    def name(self) -> str:
+        return "mark_delete"
+
+    def patch(self, arg: Optional[str] = None, **env: str) -> Json:
+        return {"delete": True}
+
+
+class ConsoleSink(CLISink):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "out"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Sink[None]:
+        async def out(flow: Stream) -> None:
+            async with flow.stream() as ctx:
+                async for item in ctx:
+                    print(item)
+
+        return out
+
+
+class ListSink(CLISink):  # type: ignore
+    @property
+    def name(self) -> str:
+        return "out"
+
+    async def parse(self, arg: Optional[str] = None, **env: str) -> Sink[List[Json]]:
+        return lambda in_stream: stream.list(in_stream)
+
+
+def all_sources(d: CLIDependencies) -> List[CLISource]:
+    return [EchoSource(d), MatchSource(d)]
+
+
+def all_sinks(d: CLIDependencies) -> List[CLISink]:
+    return [ConsoleSink(d), ListSink(d)]
+
+
+def all_commands(d: CLIDependencies) -> List[CLICommand]:
+    return [ChunkCommand(d), FlattenCommand(d), CountCommand(d), DesireCommand(d), MarkDeleteCommand(d), UniqCommand(d)]
+
+
+def all_parts(d: CLIDependencies) -> List[CLIPart]:
+    # noinspection PyTypeChecker
+    return all_sources(d) + all_commands(d) + all_sinks(d)

--- a/keepercore/core/cli/command.py
+++ b/keepercore/core/cli/command.py
@@ -88,7 +88,9 @@ class MatchSource(CLISource):  # type: ignore
         query = parse_query(arg)
         model = await self.dependencies.model_handler.load_model()
         db = self.dependencies.db_access.get_graph_db(graph_name)
-        return db.query_list(QueryModel(query, model, query_section), with_system_props=True)
+        query_model = QueryModel(query, model, query_section)
+        db.to_query(query_model)  # only here to validate the query itself (can throw)
+        return db.query_list(query_model, with_system_props=True)
 
 
 class EnvSource(CLISource):  # type: ignore

--- a/keepercore/core/error.py
+++ b/keepercore/core/error.py
@@ -29,3 +29,7 @@ class NoSuchBatchError(DatabaseError, NotFoundError):
     def __init__(self, change_id: str):
         super().__init__(f"No batch with given id {change_id}")
         self.change_id = change_id
+
+
+class CLIParseError(DomainError):
+    pass

--- a/keepercore/core/event_bus.py
+++ b/keepercore/core/event_bus.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 class CoreEvent:
     NodeCreated = "node-created"
     NodeUpdated = "node-updated"
+    NodesDesiredUpdated = "nodes-desired-updated"
     NodeDeleted = "node-deleted"
     SubGraphUpdated = "subgraph-updated"
     BatchUpdateSubGraphAdded = "batch-update-subgraph-added"

--- a/keepercore/core/model/model.py
+++ b/keepercore/core/model/model.py
@@ -17,7 +17,8 @@ from parsy import regex, string, Parser
 
 from core.model.typed_model import from_js
 from core.types import Json, JsonElement, ValidationResult, ValidationFn
-from core.util import if_set, make_parser
+from core.util import if_set
+from core.parse_util import make_parser
 
 
 def check_type_fn(t: type, type_name: str) -> ValidationFn:

--- a/keepercore/core/model/model_handler.py
+++ b/keepercore/core/model/model_handler.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from typing import List, Tuple, Optional
 
 from plantuml import PlantUML
@@ -11,7 +12,21 @@ from core.util import exist
 log = logging.getLogger(__name__)
 
 
-class ModelHandler:
+class ModelHandler(ABC):
+    @abstractmethod
+    async def load_model(self) -> Model:
+        pass
+
+    @abstractmethod
+    async def uml_image(self, show_packages: Optional[List[str]] = None, output: str = "svg") -> bytes:
+        pass
+
+    @abstractmethod
+    async def update_model(self, kinds: List[Kind]) -> Model:
+        pass
+
+
+class ModelHandlerDB(ModelHandler):
     def __init__(self, db: ModelDB, plantuml_server: str):
         self.db = db
         self.plantuml_server = plantuml_server

--- a/keepercore/core/parse_util.py
+++ b/keepercore/core/parse_util.py
@@ -1,0 +1,60 @@
+from typing import Callable
+
+from parsy import Parser, generate, regex, string, digit
+
+
+def make_parser(fn: Callable[[], Parser]) -> Parser:
+    """
+    Make typed parser (required for mypy).
+    """
+    return generate(fn)
+
+
+whitespace: Parser = regex(r"\s*")
+
+
+def lexeme(p: Parser) -> Parser:
+    """
+    Create a whitespace tolerant parser from a given parser.
+    """
+    return whitespace >> p << whitespace
+
+
+space_dp = regex(r"\s+")
+lparen_dp = string("(")
+rparen_dp = string(")")
+l_bracket_dp = string("[")
+r_bracket_dp = string("]")
+l_curly_dp = string("{")
+r_curly_dp = string("}")
+gt_dp = string(">")
+lt_dp = string("<")
+colon_dp = string(":")
+comma_dp = string(",")
+dot_dot_dp = string("..")
+equals_dp = string("=")
+integer_dp = digit.at_least(1).concat().map(int)
+float_dp = (digit.many() + string(".").result(["."]) + digit.many()).concat().map(float)
+variable_dp = regex("[A-Za-z][A-Za-z0-9_.*\\[\\]]*")
+literal_dp = regex("[A-Za-z][A-Za-z0-9_]*")
+
+string_part_dp = regex(r'[^"\\]+')
+string_esc_dp = string("\\") >> (
+    string("\\")
+    | string("/")
+    | string('"')
+    | string("b").result("\b")
+    | string("f").result("\f")
+    | string("n").result("\n")
+    | string("r").result("\r")
+    | string("t").result("\t")
+    | regex(r"u[0-9a-fA-F]{4}").map(lambda s: chr(int(s[1:], 16)))
+)
+string_dp = (string_part_dp | string_esc_dp).many().concat()
+quoted_string_dp = string('"') >> string_dp << string('"')
+
+true_dp = string("true").result(True)
+false_dp = string("false").result(False)
+null_dp = string("null").result(None)
+
+value_dp = float_dp | integer_dp | true_dp | false_dp | null_dp | literal_dp | quoted_string_dp

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -1,8 +1,33 @@
 from functools import reduce
 
-from parsy import string, regex, digit, success, Parser
+from parsy import success, string, Parser
 
 from core.model.graph_access import EdgeType
+from core.parse_util import (
+    lparen_dp,
+    lexeme,
+    rparen_dp,
+    l_bracket_dp,
+    r_bracket_dp,
+    l_curly_dp,
+    r_curly_dp,
+    gt_dp,
+    lt_dp,
+    colon_dp,
+    comma_dp,
+    equals_dp,
+    true_dp,
+    false_dp,
+    dot_dot_dp,
+    null_dp,
+    float_dp,
+    integer_dp,
+    variable_dp,
+    literal_dp,
+    string_dp,
+    make_parser,
+    whitespace,
+)
 from core.query.model import (
     Predicate,
     CombinedTerm,
@@ -16,14 +41,6 @@ from core.query.model import (
     AggregateFunction,
     Aggregate,
 )
-from core.util import make_parser
-
-whitespace: Parser = regex(r"\s*")
-
-
-def lexeme(p: Parser) -> Parser:
-    return whitespace >> p << whitespace
-
 
 operation_p = reduce(
     lambda x, y: x | y, [lexeme(string(a)) for a in ["<=", ">=", ">", "<", "==", "!=", "=~", "!~", "in", "not in"]]
@@ -34,40 +51,26 @@ function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet"
 
 preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type"]])
 
-lparen_p = lexeme(string("("))
-rparen_p = lexeme(string(")"))
-l_bracket_p = lexeme(string("["))
-r_bracket_p = lexeme(string("]"))
-l_curly_p = lexeme(string("{"))
-r_curly_p = lexeme(string("}"))
-gt_p = lexeme(string(">"))
-lt_p = lexeme(string("<"))
-colon_p = lexeme(string(":"))
-comma_p = lexeme(string(","))
-dot_dot_p = lexeme(string(".."))
-equals_p = lexeme(string("="))
-true_p = lexeme(string("true")).result(True)
-false_p = lexeme(string("false")).result(False)
-null_p = lexeme(string("null")).result(None)
-integer_p = digit.at_least(1).concat().map(int)
-float_p = (digit.many() + string(".").result(["."]) + digit.many()).concat().map(float)
-variable_p = lexeme(regex("[A-Za-z][A-Za-z0-9_.*\\[\\]]*"))
-literal_p = lexeme(regex("[A-Za-z][A-Za-z0-9_]*"))
-
-string_part = regex(r'[^"\\]+')
-string_esc = string("\\") >> (
-    string("\\")
-    | string("/")
-    | string('"')
-    | string("b").result("\b")
-    | string("f").result("\f")
-    | string("n").result("\n")
-    | string("r").result("\r")
-    | string("t").result("\t")
-    | regex(r"u[0-9a-fA-F]{4}").map(lambda s: chr(int(s[1:], 16)))
-)
-string_p = (string_part | string_esc).many().concat()
-quoted_string_p = lexeme(string('"') >> string_p << string('"'))
+lparen_p = lexeme(lparen_dp)
+rparen_p = lexeme(rparen_dp)
+l_bracket_p = lexeme(l_bracket_dp)
+r_bracket_p = lexeme(r_bracket_dp)
+l_curly_p = lexeme(l_curly_dp)
+r_curly_p = lexeme(r_curly_dp)
+gt_p = lexeme(gt_dp)
+lt_p = lexeme(lt_dp)
+colon_p = lexeme(colon_dp)
+comma_p = lexeme(comma_dp)
+dot_dot_p = lexeme(dot_dot_dp)
+equals_p = lexeme(equals_dp)
+true_p = lexeme(true_dp)
+false_p = lexeme(false_dp)
+null_p = lexeme(null_dp)
+float_p = lexeme(float_dp)
+integer_p = lexeme(integer_dp)
+variable_p = lexeme(variable_dp)
+literal_p = lexeme(literal_dp)
+quoted_string_p = lexeme(string('"') >> string_dp << string('"'))
 
 
 @make_parser

--- a/keepercore/core/static/api-doc.yaml
+++ b/keepercore/core/static/api-doc.yaml
@@ -15,12 +15,16 @@ tags:
       description: Endpoints to manipulate the reported data in the graph.
     - name: graph_desired
       description: Endpoints to manipulate the desired data in the graph.
+    - name: cli
+      description: Endpoints to evaluate and execute cli commands
     - name: system
       description: Endpoints to get information about the system.
     - name: debug
       description: Endpoints to debug the system
 
 paths:
+
+    # region model
     /model:
         get:
             summary: "Get the currently defined model."
@@ -64,8 +68,9 @@ paths:
             responses:
                 "200":
                     description: "Returns the model as uml diagram in svg format"
+    # endregion
 
-
+    # region graph management
     /graph:
         get:
             summary: "List all graphs"
@@ -142,6 +147,9 @@ paths:
                     content:
                         text/plain:
                             example: "Graph deleted."
+    # endregion
+
+    # region graph reported
     /graph/{graph_id}/reported/search:
         get:
             summary: "Search the graph"
@@ -330,7 +338,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/GraphUpdate"
-
     /graph/{graph_id}/reported/batch/sub_graph/{parent_node_id}:
         post:
             summary: "Replace a given subgraph which lives under the given parent node id in a batch"
@@ -646,7 +653,9 @@ paths:
                             schema:
                                 type: object
                                 additionalProperties: true
+    # endregion
 
+    # region graph desired
     /graph/{graph_id}/desired/node/{node_id}:
         get:
             summary: "Get the node and desired content with the given node id"
@@ -708,7 +717,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DesiredNode"
-
     /graph/{graph_id}/desired/query:
         post:
             summary: "Query this graph in the desired section"
@@ -899,8 +907,9 @@ paths:
                             schema:
                                 type: object
                                 additionalProperties: true
+    # endregion
 
-
+    # region events
     /events:
         get:
             summary: "Register as event listener and receive all events."
@@ -922,7 +931,95 @@ paths:
             responses:
                 default:
                     description: ""
+    # endregion
 
+    # region: cli
+    /cli/evaluate:
+        post:
+            summary: "Evaluate a cli command"
+            description: |
+                This method can be used to analyze if the command can be interpreted without executing it.
+                When this method returns a 200 OK, the command can be parsed and evaluated.
+            parameters:
+                - name: env
+                  description: "All query parameter form the environment passed to the CLI interpreter."
+                  in: query
+                  schema:
+                      type: object
+                      additionalProperties: true
+            requestBody:
+                description: |
+                    The command will be sent as request body.
+                    A command can contain multiple command line separated by semicolon.
+                    Every single line can contain multiple commands that are combined via the pipe operator.
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: echo [1,2,3,4,5,6] | count
+            tags:
+                - cli
+            responses:
+                "200":
+                    description: When the command can be evaluated.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    additionalProperties: true
+                "300":
+                    description: When the command can not be evaluated.
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+
+    /cli/execute:
+        post:
+            summary: "Execute a cli command"
+            description:  |
+                The body defines the command to execute.
+                The command is executed and the result is returned to the client.
+                Request and execution are synchronized: the request is done, when the command is done.
+            parameters:
+                - name: env
+                  description: "All query parameter form the environment passed to the CLI interpreter."
+                  in: query
+                  schema:
+                      type: object
+                      additionalProperties: true
+            requestBody:
+                description: |
+                    The command will be sent as request body.
+                    A command can contain multiple command line separated by semicolon.
+                    Every single line can contain multiple commands that are combined via the pipe operator.
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: echo [1,2,3,4,5,6] | count
+            tags:
+                - cli
+            responses:
+                "200":
+                    description: The result of the command.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    additionalProperties: true
+                        application/x-ndjson:
+                            schema:
+                                type: array
+                                items:
+                                    type: object
+                                    additionalProperties: true
+
+    # endregion
 
 components:
     schemas:

--- a/keepercore/core/util.py
+++ b/keepercore/core/util.py
@@ -15,6 +15,10 @@ AnyT = TypeVar("AnyT")
 AnyR = TypeVar("AnyR")
 
 
+def identity(o: AnyT) -> AnyT:
+    return o
+
+
 def group_by(f: Callable[[AnyT], AnyR], iterable: Iterable[AnyT]) -> Dict[AnyR, List[AnyT]]:
     """
     Group iterable by key provided by given key function.
@@ -83,6 +87,29 @@ def make_parser(fn: Callable[[], Parser]) -> Parser:
     Make typed parser (required for mypy).
     """
     return generate(fn)
+
+
+def split_esc(s: str, delim: str) -> List[str]:
+    """Split with support for delimiter escaping
+
+    Via: https://stackoverflow.com/a/29107566
+    """
+    i = 0
+    res: List[str] = []
+    buf = ""
+    while True:
+        j, e = s.find(delim, i), 0
+        if j < 0:  # end reached
+            return res + [buf + s[i:]]  # add remainder
+        while j - e and s[j - e - 1] == "\\":
+            e += 1  # number of escapes
+        d = e // 2  # number of double escapes
+        if e != d * 2:  # odd number of escapes
+            buf += s[i : j - d - 1] + s[j]  # noqa: E203 add the escaped char.
+            i = j + 1  # and skip it
+            continue  # add more to buf
+        res.append(buf + s[i : j - d])  # noqa: E203
+        i, buf = j + len(delim), ""  # start after delim
 
 
 class Periodic:

--- a/keepercore/core/util.py
+++ b/keepercore/core/util.py
@@ -4,8 +4,8 @@ from asyncio import Task
 from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import suppress
-from datetime import timedelta
-from typing import Any, Callable, Optional, Awaitable, Dict, TypeVar, List, Tuple
+from datetime import timedelta, datetime, timezone
+from typing import Any, Callable, Optional, Awaitable, Dict, TypeVar, List, Tuple, Mapping, MutableSequence
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +15,17 @@ AnyR = TypeVar("AnyR")
 
 def identity(o: AnyT) -> AnyT:
     return o
+
+
+UTC_Date_Format = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_str(dt: datetime = utc()) -> str:
+    return dt.strftime(UTC_Date_Format)
 
 
 def group_by(f: Callable[[AnyT], AnyR], iterable: Iterable[AnyT]) -> Dict[AnyR, List[AnyT]]:
@@ -137,3 +148,48 @@ class Periodic:
                     await result
             except BaseException as ex:
                 log.warning(f"Periodic function {self.name} caught an exception: {ex}")
+
+
+class AccessNone:
+    def __init__(self, not_existent: Any = None):
+        self.__not_existent = not_existent
+
+    def __getitem__(self, item: Any) -> Any:
+        return self
+
+    def __getattr__(self, name: Any) -> Any:
+        return self
+
+    def __str__(self) -> str:
+        return str(self.__not_existent)
+
+
+class AccessJson(dict[Any, Any]):
+    """
+    Extend dict in order to allow python like property access
+    as well as exception safe access for non existent properties.
+    """
+
+    def __init__(self, mapping: Mapping[Any, Any], not_existent: Any = None) -> None:
+        super().__init__(mapping)
+        self.__not_existent = AccessNone(not_existent)
+
+    def __getitem__(self, item: Any) -> Any:
+        return AccessJson.wrap(super().__getitem__(item), self.__not_existent) if item in self else self.__not_existent
+
+    def __getattr__(self, name: Any) -> Any:
+        return AccessJson.wrap(self[name], self.__not_existent) if name in self else self.__not_existent
+
+    @staticmethod
+    def wrap(obj: Any, not_existent: Any) -> Any:
+        # dict like data structure -> wrap whole element
+        if isinstance(obj, AccessJson):
+            return obj
+        elif isinstance(obj, Mapping):
+            return AccessJson(obj, not_existent)
+        # list like data structure -> wrap all elements
+        elif isinstance(obj, MutableSequence):
+            return [AccessJson.wrap(item, not_existent) for item in obj]
+        # simply return the object
+        else:
+            return obj

--- a/keepercore/core/util.py
+++ b/keepercore/core/util.py
@@ -7,8 +7,6 @@ from contextlib import suppress
 from datetime import timedelta
 from typing import Any, Callable, Optional, Awaitable, Dict, TypeVar, List, Tuple
 
-from parsy import Parser, generate
-
 log = logging.getLogger(__name__)
 
 AnyT = TypeVar("AnyT")
@@ -80,13 +78,6 @@ def if_set(x: Optional[AnyT], func: Callable[[AnyT], Any], if_not: Any = None) -
     :return: the result of the function or if_not
     """
     return func(x) if x is not None else if_not
-
-
-def make_parser(fn: Callable[[], Parser]) -> Parser:
-    """
-    Make typed parser (required for mypy).
-    """
-    return generate(fn)
 
 
 def split_esc(s: str, delim: str) -> List[str]:

--- a/keepercore/core/web/api.py
+++ b/keepercore/core/web/api.py
@@ -14,10 +14,12 @@ from aiohttp.web_exceptions import HTTPRedirection
 from aiohttp.web_request import Request
 from aiohttp.web_response import StreamResponse
 from aiohttp_swagger3 import SwaggerFile, SwaggerUiSettings
+from aiostream import stream
 from networkx import MultiDiGraph
 from networkx.readwrite import cytoscape_data
 
 from core import feature
+from core.cli.cli import CLI
 from core.db.db_access import DbAccess
 from core.db.model import QueryModel
 from core.error import NotFoundError
@@ -44,12 +46,14 @@ class Api:
         subscription_handler: SubscriptionHandler,
         workflow_handler: WorkflowHandler,
         event_bus: EventBus,
+        cli: CLI,
     ):
         self.db = db
         self.model_handler = model_handler
         self.subscription_handler = subscription_handler
         self.workflow_handler = workflow_handler
         self.event_bus = event_bus
+        self.cli = cli
         self.app = web.Application(middlewares=[self.error_handler])
         static_path = os.path.abspath(os.path.dirname(__file__) + "/../static")
         r = "reported"
@@ -105,6 +109,8 @@ class Api:
                 web.post("/subscription/{subscriber_id}/{event_type}", self.add_subscription),
                 web.delete("/subscription/{subscriber_id}/{event_type}", self.delete_subscription),
                 web.get("/subscription/{subscriber_id}/handle", self.handle_subscribed),
+                # CLI
+                web.post("/execute", self.execute),
                 # Event operations
                 web.get("/events", self.handle_events),
                 # Serve static filed
@@ -392,6 +398,16 @@ class Api:
         else:
             await self.db.delete_graph(graph_id)
             return web.HTTPOk(body="Graph deleted.")
+
+    async def execute(self, request: Request) -> StreamResponse:
+        # all query parameter become the env of this command
+        env = request.query
+        command = await request.text()
+        # we want to eagerly evaluate the command, so that parse exceptions will throw directly here
+        parsed = await self.cli.evaluate_cli_command(command, **env)
+        # flat the results from the different command lines
+        result = stream.concat(stream.iterate(p.generator for p in parsed))
+        return await self.stream_response_from_gen(request, result)
 
     @staticmethod
     async def read_graph(request: Request, md: Model) -> MultiDiGraph:

--- a/keepercore/requirements-dev.txt
+++ b/keepercore/requirements-dev.txt
@@ -9,7 +9,7 @@ deepdiff==5.5.0
 mypy==0.910
 pip==21.2.4
 bump2version==1.0.1
-wheel==0.36.2
+wheel==0.37.0
 flake8==3.9.2
 pep8-naming==0.12.1
 tox==3.24.1

--- a/keepercore/requirements.txt
+++ b/keepercore/requirements.txt
@@ -14,3 +14,4 @@ toolz==0.11.1
 transitions==0.8.8
 APScheduler==3.7.0
 aiostream==0.4.3
+tzlocal==2.1

--- a/keepercore/requirements.txt
+++ b/keepercore/requirements.txt
@@ -13,3 +13,4 @@ python-dateutil==2.8.2
 toolz==0.11.1
 transitions==0.8.8
 APScheduler==3.7.0
+aiostream==0.4.3

--- a/keepercore/tests/core/cli/cli_test.py
+++ b/keepercore/tests/core/cli/cli_test.py
@@ -19,7 +19,7 @@ from core.db.graphdb import ArangoGraphDB
 from core.error import CLIParseError
 from core.event_bus import EventBus
 from core.model.model import Model
-from core.types import Json
+from core.types import JsonElement
 
 # noinspection PyUnresolvedReferences
 from tests.core.db.graphdb_test import filled_graph_db, graph_db, test_db, foo_model
@@ -42,7 +42,7 @@ def cli(cli_deps: CLIDependencies) -> CLI:
 
 
 @fixture
-async def sink(cli_deps: CLIDependencies) -> Sink[List[Json]]:
+async def sink(cli_deps: CLIDependencies) -> Sink[List[JsonElement]]:
     return await ListSink(cli_deps).parse()
 
 
@@ -113,11 +113,18 @@ async def test_order_of_commands(cli: CLI) -> None:
 
 
 @pytest.mark.asyncio
-async def test_help(cli: CLI, sink: Sink[List[Json]]) -> None:
+async def test_help(cli: CLI, sink: Sink[List[JsonElement]]) -> None:
     result = await cli.execute_cli_command("help", sink)
     assert len(result[0]) == 1
     print(result)
 
     result = await cli.execute_cli_command("help count", sink)
     assert len(result[0]) == 1
+    print(result)
+
+
+@pytest.mark.asyncio
+async def test_parse_env_vars(cli: CLI, sink: Sink[List[JsonElement]]) -> None:
+    result = await cli.execute_cli_command('test=foo bla="bar"   d=true env', sink)
+    assert result[0] == [{"test": "foo", "bla": "bar", "d": True}]
     print(result)

--- a/keepercore/tests/core/cli/cli_test.py
+++ b/keepercore/tests/core/cli/cli_test.py
@@ -1,0 +1,123 @@
+from typing import List
+
+import pytest
+from pytest import fixture
+
+from core.cli.cli import CLI, CLIDependencies, Sink
+from core.cli.command import (
+    EchoSource,
+    ListSink,
+    MatchSource,
+    CountCommand,
+    ChunkCommand,
+    all_parts,
+    FlattenCommand,
+    UniqCommand,
+)
+from core.db.db_access import DbAccess
+from core.db.graphdb import ArangoGraphDB
+from core.error import CLIParseError
+from core.event_bus import EventBus
+from core.model.model import Model
+from core.types import Json
+
+# noinspection PyUnresolvedReferences
+from tests.core.db.graphdb_test import filled_graph_db, graph_db, test_db, foo_model
+
+# noinspection PyUnresolvedReferences
+from tests.core.event_bus_test import event_bus
+from tests.core.model import ModelHandlerStatic
+
+
+@fixture
+def cli_deps(filled_graph_db: ArangoGraphDB, event_bus: EventBus, foo_model: Model) -> CLIDependencies:
+    db_access = DbAccess(filled_graph_db.db.db, event_bus)
+    model_handler = ModelHandlerStatic(foo_model)
+    return CLIDependencies(event_bus, db_access, model_handler)
+
+
+@fixture
+def cli(cli_deps: CLIDependencies) -> CLI:
+    return CLI(cli_deps, all_parts(cli_deps))
+
+
+@fixture
+async def sink(cli_deps: CLIDependencies) -> Sink[List[Json]]:
+    return await ListSink(cli_deps).parse()
+
+
+@pytest.mark.asyncio
+async def test_multi_command(cli: CLI) -> None:
+    nums = ",".join([f'{{ "num": {a}}}' for a in range(0, 100)])
+    source = "echo [" + nums + "," + nums + "]"
+    command1 = f"{source} | chunk 7"
+    command2 = f"{source} | chunk | flatten | uniq"
+    command3 = f"{source} | chunk 10"
+    commands = ";".join([command1, command2, command3])
+    result = await cli.evaluate_cli_command(commands)
+    assert len(result) == 3
+    line1, line2, line3 = result
+    assert len(line1.parts) == 2
+    l1p1, l1p2 = line1.parts
+    assert isinstance(l1p1, EchoSource)
+    assert isinstance(l1p2, ChunkCommand)
+    assert len(line2.parts) == 4
+    l2p1, l2p2, l2p3, l2p4 = line2.parts
+    assert isinstance(l2p1, EchoSource)
+    assert isinstance(l2p2, ChunkCommand)
+    assert isinstance(l2p3, FlattenCommand)
+    assert isinstance(l2p4, UniqCommand)
+    assert len(line3.parts) == 2
+    l3p1, l3p2 = line3.parts
+    assert isinstance(l3p1, EchoSource)
+    assert isinstance(l3p2, ChunkCommand)
+
+
+@pytest.mark.asyncio
+async def test_query_database(cli: CLI) -> None:
+    env = {"graphdb": "ns"}
+    query = 'match isinstance("foo") and some_string=="hello" --> f>12 and f<100 and g[*]==2'
+    count = "count f"
+    commands = "|".join([query, count])
+    result = await cli.evaluate_cli_command(commands, **env)
+    assert len(result) == 1
+    line1 = result[0]
+    assert len(line1.parts) == 2
+    p1, p2 = line1.parts
+    assert isinstance(p1, MatchSource)
+    assert isinstance(p2, CountCommand)
+
+    with pytest.raises(CLIParseError):
+        await cli.evaluate_cli_command("match this is not a query", **env)  # command is un-parsable
+
+    with pytest.raises(CLIParseError):
+        await cli.evaluate_cli_command("match id==3")  # no graphdb specified
+
+
+@pytest.mark.asyncio
+async def test_unknown_command(cli: CLI) -> None:
+    with pytest.raises(CLIParseError) as ex:
+        await cli.evaluate_cli_command("echo foo | uniq |  some_not_existing_command")
+    assert str(ex.value) == "Command >some_not_existing_command< is not known. typo?"
+
+
+@pytest.mark.asyncio
+async def test_order_of_commands(cli: CLI) -> None:
+    with pytest.raises(CLIParseError) as ex:
+        await cli.evaluate_cli_command("uniq")
+    assert str(ex.value) == "Command >uniq< can not be used in this position: no source data given"
+
+    with pytest.raises(CLIParseError) as ex:
+        await cli.evaluate_cli_command("echo foo | uniq | match bla==23")
+    assert str(ex.value) == "Command >match< can not be used in this position: must be the first command"
+
+
+@pytest.mark.asyncio
+async def test_help(cli: CLI, sink: Sink[List[Json]]) -> None:
+    result = await cli.execute_cli_command("help", sink)
+    assert len(result[0]) == 1
+    print(result)
+
+    result = await cli.execute_cli_command("help count", sink)
+    assert len(result[0]) == 1
+    print(result)

--- a/keepercore/tests/core/cli/command_test.py
+++ b/keepercore/tests/core/cli/command_test.py
@@ -39,8 +39,7 @@ async def test_echo_source(cli: CLI, sink: Sink[List[str]]) -> None:
 
 @pytest.mark.asyncio
 async def test_match_source(cli: CLI, sink: Sink[List[str]]) -> None:
-    env = {"graphdb": "ns"}
-    result = await cli.execute_cli_command('match isinstance("foo") and some_int==0 --> identifier=~"9_"', sink, **env)
+    result = await cli.execute_cli_command('match isinstance("foo") and some_int==0 --> identifier=~"9_"', sink)
     assert len(result[0]) == 10
 
 
@@ -84,8 +83,7 @@ async def test_uniq_command(cli: CLI, sink: Sink[List[str]], echo_source: str) -
 
 @pytest.mark.asyncio
 async def test_desire_command(cli: CLI, sink: Sink[List[str]]) -> None:
-    env = {"graphdb": "ns"}
-    result = await cli.execute_cli_command('match isinstance("foo") | desire a="test" b=1 c=true', sink, **env)
+    result = await cli.execute_cli_command('match isinstance("foo") | desire a="test" b=1 c=true', sink)
     assert len(result[0]) == 11
     for elem in result[0]:
         assert elem["desired"] == {"a": "test", "b": 1, "c": True}
@@ -93,8 +91,7 @@ async def test_desire_command(cli: CLI, sink: Sink[List[str]]) -> None:
 
 @pytest.mark.asyncio
 async def test_mark_delete_command(cli: CLI, sink: Sink[List[str]]) -> None:
-    env = {"graphdb": "ns"}
-    result = await cli.execute_cli_command('match isinstance("foo") | mark_delete', sink, **env)
+    result = await cli.execute_cli_command('match isinstance("foo") | mark_delete', sink)
     assert len(result[0]) == 11
     for elem in result[0]:
         assert elem["desired"] == {"delete": True}

--- a/keepercore/tests/core/cli/command_test.py
+++ b/keepercore/tests/core/cli/command_test.py
@@ -1,0 +1,113 @@
+from typing import List
+
+import pytest
+from pytest import fixture
+
+from core.cli.cli import CLI, Sink, CLIDependencies
+
+# noinspection PyUnresolvedReferences
+from tests.core.db.graphdb_test import filled_graph_db, graph_db, test_db, foo_model
+
+# noinspection PyUnresolvedReferences
+from core.cli.command import ConsoleSink, ListSink
+
+# noinspection PyUnresolvedReferences
+from tests.core.cli.cli_test import cli, sink, cli_deps
+
+# noinspection PyUnresolvedReferences
+from tests.core.event_bus_test import event_bus
+
+
+@fixture
+def echo_source() -> str:
+    nums = ",".join([f'{{ "num": {a}}}' for a in range(0, 100)])
+    return "echo [" + nums + "," + nums + "]"
+
+
+@pytest.mark.asyncio
+async def test_echo_source(cli: CLI, sink: Sink[List[str]]) -> None:
+    result = await cli.execute_cli_command('echo [{"a": 1}, {"b":2}]', sink)
+    assert result[0] == [{"a": 1}, {"b": 2}]
+
+    result = await cli.execute_cli_command("echo [1,2,3,4]", sink)
+    assert result[0] == [1, 2, 3, 4]
+
+    result = await cli.execute_cli_command('echo "foo bla bar"', sink)
+    assert result[0] == ["foo bla bar"]
+
+
+@pytest.mark.asyncio
+async def test_match_source(cli: CLI, sink: Sink[List[str]]) -> None:
+    env = {"graphdb": "ns"}
+    result = await cli.execute_cli_command('match isinstance("foo") and some_int==0 --> identifier=~"9_"', sink, **env)
+    assert len(result[0]) == 10
+
+
+@pytest.mark.asyncio
+async def test_count_command(cli: CLI, sink: Sink[List[str]], echo_source: str) -> None:
+    # count instances
+    result = await cli.execute_cli_command(f"{echo_source} | count", sink)
+    assert len(result[0]) == 1
+    assert result[0][0] == {"matched": 200, "not_matched": 0}
+
+    # count attributes
+    result = await cli.execute_cli_command(f"{echo_source} | count num", sink)
+    assert len(result[0]) == 1
+    assert result[0][0] == {"matched": 9900, "not_matched": 0}
+
+    # count unknown attributes
+    result = await cli.execute_cli_command(f"{echo_source} | count does_not_exist", sink)
+    assert len(result[0]) == 1
+    assert result[0][0] == {"matched": 0, "not_matched": 200}
+
+
+@pytest.mark.asyncio
+async def test_chunk_command(cli: CLI, sink: Sink[List[str]], echo_source: str) -> None:
+    result = await cli.execute_cli_command(f"{echo_source} | chunk 50", sink)
+    assert len(result[0]) == 4  # 200 in chunks of 50
+    for a in result[0]:
+        assert len(a) == 50
+
+
+@pytest.mark.asyncio
+async def test_flatten_command(cli: CLI, sink: Sink[List[str]], echo_source: str) -> None:
+    result = await cli.execute_cli_command(f"{echo_source} | chunk 50 | flatten", sink)
+    assert len(result[0]) == 200
+
+
+@pytest.mark.asyncio
+async def test_uniq_command(cli: CLI, sink: Sink[List[str]], echo_source: str) -> None:
+    result = await cli.execute_cli_command(f"{echo_source} | uniq", sink)
+    assert len(result[0]) == 100
+
+
+@pytest.mark.asyncio
+async def test_desire_command(cli: CLI, sink: Sink[List[str]]) -> None:
+    env = {"graphdb": "ns"}
+    result = await cli.execute_cli_command('match isinstance("foo") | desire a="test", b=1, c=true', sink, **env)
+    assert len(result[0]) == 11
+    for elem in result[0]:
+        assert elem["desired"] == {"a": "test", "b": 1, "c": True}
+
+
+@pytest.mark.asyncio
+async def test_mark_delete_command(cli: CLI, sink: Sink[List[str]]) -> None:
+    env = {"graphdb": "ns"}
+    result = await cli.execute_cli_command('match isinstance("foo") | mark_delete', sink, **env)
+    assert len(result[0]) == 11
+    for elem in result[0]:
+        assert elem["desired"] == {"delete": True}
+
+
+@pytest.mark.asyncio
+async def test_console_sink(cli: CLI, cli_deps: CLIDependencies) -> None:
+    sink = await ConsoleSink(cli_deps).parse()
+    result = await cli.execute_cli_command('echo "you should see this on the command line"', sink)
+    assert result[0] is None
+
+
+@pytest.mark.asyncio
+async def test_list_sink(cli: CLI, cli_deps: CLIDependencies) -> None:
+    sink = await ListSink(cli_deps).parse()
+    result = await cli.execute_cli_command("echo [1,2,3]", sink)
+    assert result == [[1, 2, 3]]

--- a/keepercore/tests/core/model/__init__.py
+++ b/keepercore/tests/core/model/__init__.py
@@ -1,0 +1,19 @@
+from typing import Optional, List
+
+from core.model.model import Model, Kind
+from core.model.model_handler import ModelHandler
+
+
+class ModelHandlerStatic(ModelHandler):
+    def __init__(self, model: Model):
+        self.model = model
+
+    async def load_model(self) -> Model:
+        return self.model
+
+    async def uml_image(self, show_packages: Optional[List[str]] = None, output: str = "svg") -> bytes:
+        raise NotImplemented
+
+    async def update_model(self, kinds: List[Kind]) -> Model:
+        self.model = Model.from_kinds(kinds)
+        return self.model

--- a/keepercore/tests/core/util_test.py
+++ b/keepercore/tests/core/util_test.py
@@ -1,0 +1,18 @@
+import json
+
+from core.util import AccessJson
+
+
+def test_access_json() -> None:
+    js = {"a": "a", "b": {"c": "c", "d": {"e": "e", "f": [0, 1, 2, 3, 4]}}}
+    access = AccessJson(js, "null")
+
+    assert access.a == "a"
+    assert access.b.d.f[2] == 2
+    assert str(access.foo.bla.bar[23].now) is "null"
+    assert json.dumps(access.b.d, sort_keys=True) == '{"e": "e", "f": [0, 1, 2, 3, 4]}'
+
+    assert access["a"] == "a"
+    assert access["b"]["d"]["f"][2] == 2
+    assert str(access["foo"]["bla"]["bar"][23]["now"]) is "null"
+    assert json.dumps(access["b"]["d"], sort_keys=True) == '{"e": "e", "f": [0, 1, 2, 3, 4]}'


### PR DESCRIPTION
This PR introduces a CLI that tries to match the UI of the existing CLI in cloudkeeper (work in progress).
A command in `keepercore` can contain several command lines chained by a semicolon.
Every command line consists of one or more commands chained by a pipe.
Data emitting commands are called sources and transformation commands are called flow commands.
Every command line has this structure: `source | flow | ... | flow | sink`.
Since the command line interpreter is remote, the sink is always the http response.

In order to test this behaviour locally, start up keepercore and fire this on your command line:
```
▶ echo 'help' | http :8080/cli/execute  | jq -r ".[0]"                   
```

Which currently gives you this result:
```
Valid placeholder string:
   @UTC@ -> 2021-08-18T13:12:51Z
   @NOW@ -> 2021-08-18T15:12:51Z
   @TODAY@ -> 2021-08-18
   @TOMORROW@ -> 2021-08-19
   @YESTERDAY@ -> 2021-08-17
   @YEAR@ -> 2021
   @MONTH@ -> 08
   @DAY@ -> 18
   @TIME@ -> 15:12:51
   @HOUR@ -> 15
   @MINUTE@ -> 12
   @SECOND@ -> 51
   @TZ_OFFSET@ -> +0200
   @TZ@ -> CEST
   @MONDAY@ -> 2021-08-23
   @TUESDAY@ -> 2021-08-24
   @WEDNESDAY@ -> 2021-08-18
   @THURSDAY@ -> 2021-08-19
   @FRIDAY@ -> 2021-08-20
   @SATURDAY@ -> 2021-08-21
   @SUNDAY@ -> 2021-08-22

Available Commands:
   echo - Parse json and pass parsed objects to the output stream.
   env - Retrieve the environment and pass it to the output stream.
   match - Query the database and pass the results to the output stream.
   chunk - Chunk incoming elements in batches.
   flatten - Take incoming batches of elements and flattens them to a stream of single elements.
   count - Count incoming elements or sum defined property.
   desire - Allows to set arbitrary properties as desired for all incoming database objects.
   format - Transform incoming objects as string with a defined format.
   mark_delete - Mark all incoming database objects for deletion.
   uniq - Remove all duplicated objects from the stream
   help - Shows available commands, as well as help for any specific command.

Note that you can pipe commands using the pipe character (|)
and chain multiple commands using the semicolon (;).
```

Replace `help` with any other command to experiment with.
