### PR TITLE
[keepercore] Durable subscriptions

### DIFF
--- a/cloudkeeper/cloudkeeper/event.py
+++ b/cloudkeeper/cloudkeeper/event.py
@@ -234,7 +234,7 @@ class KeepercoreEvents(threading.Thread):
                 data = None
             self.register(event, data)
 
-        ws_uri = f"{self.keepercore_ws_uri}/subscription/{self.identifier}/handle"
+        ws_uri = f"{self.keepercore_ws_uri}/subscriber/{self.identifier}/handle"
         log.debug(f"{self.identifier} connecting to {ws_uri}")
         self.ws = websocket.WebSocketApp(
             ws_uri,
@@ -266,7 +266,7 @@ class KeepercoreEvents(threading.Thread):
     def registration(
         self, event: str, client: Callable, data: Optional[Dict] = None
     ) -> bool:
-        url = f"{self.keepercore_uri}/subscription/{self.identifier}/{event}"
+        url = f"{self.keepercore_uri}/subscriber/{self.identifier}/{event}"
         r = client(url, headers={"accept": "application/json"}, json=data)
         if r.status_code != 200:
             log.error(r.content)

--- a/keepercore/core/__main__.py
+++ b/keepercore/core/__main__.py
@@ -55,7 +55,7 @@ def main() -> None:
     cli_deps = CLIDependencies(event_bus, db, model)
     cli = CLI(cli_deps, all_parts(cli_deps), dict(os.environ))
 
-    subscriptions = SubscriptionHandler()
+    subscriptions = SubscriptionHandler(db.subscribers_db)
     workflow_handler = WorkflowHandler(event_bus, subscriptions, scheduler)
 
     api = Api(db, model, subscriptions, workflow_handler, event_bus, cli)

--- a/keepercore/core/__main__.py
+++ b/keepercore/core/__main__.py
@@ -55,7 +55,7 @@ def main() -> None:
     cli_deps = CLIDependencies(event_bus, db, model)
     cli = CLI(cli_deps, all_parts(cli_deps), dict(os.environ))
 
-    subscriptions = SubscriptionHandler(db.subscribers_db)
+    subscriptions = SubscriptionHandler(db.subscribers_db, event_bus)
     workflow_handler = WorkflowHandler(event_bus, subscriptions, scheduler)
 
     api = Api(db, model, subscriptions, workflow_handler, event_bus, cli)

--- a/keepercore/core/db/async_arangodb.py
+++ b/keepercore/core/db/async_arangodb.py
@@ -102,6 +102,15 @@ class AsyncArangoDBBase:
             intermediate_commit_size,
         )
 
+    async def get(
+        self,
+        collection: str,
+        document: Union[str, Json],
+        rev: Optional[str] = None,
+        check_rev: bool = True,
+    ) -> Optional[Json]:
+        return await run_async(self.db.collection(collection).get, document, rev, check_rev)
+
     async def insert(
         self,
         collection: str,

--- a/keepercore/core/db/db_access.py
+++ b/keepercore/core/db/db_access.py
@@ -7,8 +7,10 @@ from arango.database import StandardDatabase
 from dateutil.parser import parse
 
 from core.db.async_arangodb import AsyncArangoDB
+from core.db.entitydb import EventEntityDb
+from core.db.modeldb import ArangoModelDB, ModelDb
 from core.db.graphdb import ArangoGraphDB, GraphDB, EventGraphDB
-from core.db.modeldb import ArangoModelDB, ModelDB, EventModelDB
+from core.db.subscriberdb import ArangoSubscriberDb
 from core.event_bus import EventBus
 from core.util import Periodic
 
@@ -21,20 +23,21 @@ class DbAccess(ABC):
         arango_database: StandardDatabase,
         event_bus: EventBus,
         model_name: str = "model",
+        subscribers_name: str = "subscriber",
         batch_outdated: timedelta = timedelta(minutes=30),
     ):
         self.event_bus = event_bus
         self.database = arango_database
         self.db = AsyncArangoDB(arango_database)
-        self.model_name = model_name
-        self.model_db = ArangoModelDB(self.db, model_name)
-        self.model_event_db = EventModelDB(self.model_db, event_bus)
+        self.model_db = EventEntityDb(ArangoModelDB(self.db, model_name), event_bus, model_name)
+        self.subscribers_db = EventEntityDb(ArangoSubscriberDb(self.db, subscribers_name), event_bus, subscribers_name)
         self.graph_dbs: Dict[str, GraphDB] = {}
         self.batch_outdated = batch_outdated
         self.cleaner = Periodic("batch_cleaner", self.check_outdated_batches, timedelta(seconds=60))
 
     async def start(self) -> None:
         await self.model_db.create_update_schema()
+        await self.subscribers_db.create_update_schema()
         await self.cleaner.start()
 
     async def create_graph(self, name: str) -> GraphDB:
@@ -63,8 +66,8 @@ class DbAccess(ABC):
             self.graph_dbs[name] = event_db
             return event_db
 
-    def get_model_db(self) -> ModelDB:
-        return self.model_event_db
+    def get_model_db(self) -> ModelDb:
+        return self.model_db
 
     async def check_outdated_batches(self) -> None:
         now = datetime.now(timezone.utc)

--- a/keepercore/core/db/db_access.py
+++ b/keepercore/core/db/db_access.py
@@ -8,9 +8,9 @@ from dateutil.parser import parse
 
 from core.db.async_arangodb import AsyncArangoDB
 from core.db.entitydb import EventEntityDb
-from core.db.modeldb import ArangoModelDB, ModelDb
+from core.db.modeldb import ModelDb, model_db
 from core.db.graphdb import ArangoGraphDB, GraphDB, EventGraphDB
-from core.db.subscriberdb import ArangoSubscriberDb
+from core.db.subscriberdb import subscriber_db
 from core.event_bus import EventBus
 from core.util import Periodic
 
@@ -29,8 +29,8 @@ class DbAccess(ABC):
         self.event_bus = event_bus
         self.database = arango_database
         self.db = AsyncArangoDB(arango_database)
-        self.model_db = EventEntityDb(ArangoModelDB(self.db, model_name), event_bus, model_name)
-        self.subscribers_db = EventEntityDb(ArangoSubscriberDb(self.db, subscribers_name), event_bus, subscribers_name)
+        self.model_db = EventEntityDb(model_db(self.db, model_name), event_bus, model_name)
+        self.subscribers_db = EventEntityDb(subscriber_db(self.db, subscribers_name), event_bus, subscribers_name)
         self.graph_dbs: Dict[str, GraphDB] = {}
         self.batch_outdated = batch_outdated
         self.cleaner = Periodic("batch_cleaner", self.check_outdated_batches, timedelta(seconds=60))

--- a/keepercore/core/db/entitydb.py
+++ b/keepercore/core/db/entitydb.py
@@ -1,0 +1,111 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import List, AsyncGenerator, Generic, TypeVar, Optional, Type, Union, Callable
+
+from core.db.async_arangodb import AsyncArangoDB
+from core.event_bus import EventBus
+from core.model.typed_model import from_js, to_js
+from core.types import Json
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class EntityDb(ABC, Generic[T]):
+    @abstractmethod
+    async def all(self) -> AsyncGenerator[T, None]:
+        yield None  # type: ignore
+
+    @abstractmethod
+    async def update_many(self, elements: List[T]) -> None:
+        pass
+
+    @abstractmethod
+    async def get(self, key: str) -> Optional[T]:
+        pass
+
+    @abstractmethod
+    async def update(self, t: T) -> T:
+        pass
+
+    @abstractmethod
+    async def delete(self, key_or_object: Union[str, T]) -> None:
+        pass
+
+    @abstractmethod
+    async def create_update_schema(self) -> None:
+        pass
+
+
+class ArangoEntityDb(EntityDb[T], ABC):
+    def __init__(self, db: AsyncArangoDB, collection_name: str, t_type: Type[T], key_fn: Callable[[T], str]):
+        self.db = db
+        self.collection_name = collection_name
+        self.t_type = t_type
+        self.key_of = key_fn
+
+    async def all(self) -> AsyncGenerator[T, None]:
+        with await self.db.all(self.collection_name) as cursor:
+            for element in cursor:
+                yield from_js(element, self.t_type)
+
+    async def update_many(self, elements: List[T]) -> None:
+        await self.db.insert_many(self.collection_name, [self.__to_doc(kind) for kind in elements], overwrite=True)
+
+    async def get(self, key: str) -> Optional[T]:
+        result = await self.db.get(self.collection_name, key)
+        return from_js(result, self.t_type) if result else None
+
+    async def update(self, t: T) -> T:
+        await self.db.insert(self.collection_name, self.__to_doc(t), overwrite=True)
+        return t
+
+    async def delete(self, key_or_object: Union[str, T]) -> None:
+        key = key_or_object if isinstance(key_or_object, str) else self.key_of(key_or_object)
+        await self.db.delete(self.collection_name, key)
+
+    async def create_update_schema(self) -> None:
+        name = self.collection_name
+        db = self.db
+        if not await db.has_collection(name):
+            await db.create_collection(name)
+
+    async def wipe(self) -> bool:
+        return await self.db.truncate(self.collection_name)
+
+    def __to_doc(self, t: T) -> Json:
+        js = to_js(t)
+        js["_key"] = self.key_of(t)
+        return js
+
+
+class EventEntityDb(EntityDb[T]):
+    def __init__(self, db: EntityDb[T], event_bus: EventBus, entity_name: str):
+        self.db = db
+        self.event_bus = event_bus
+        self.entity_name = entity_name
+
+    async def all(self) -> AsyncGenerator[T, None]:
+        async for a in self.db.all():
+            yield a
+
+    async def update_many(self, elements: List[T]) -> None:
+        result = await self.db.update_many(elements)
+        await self.event_bus.emit_event(f"{self.entity_name}-updated-many", {"updated": [to_js(e) for e in elements]})
+        return result
+
+    async def get(self, key: str) -> Optional[T]:
+        return await self.db.get(key)
+
+    async def update(self, t: T) -> T:
+        result = await self.db.update(t)
+        await self.event_bus.emit_event(f"{self.entity_name}-updated", {"updated": to_js(result)})
+        return result
+
+    async def delete(self, key_or_object: Union[str, T]) -> None:
+        await self.db.delete(key_or_object)
+        await self.event_bus.emit_event(f"{self.entity_name}-deleted", {"deleted": to_js(key_or_object)})
+
+    async def create_update_schema(self) -> None:
+        return await self.db.create_update_schema()

--- a/keepercore/core/db/modeldb.py
+++ b/keepercore/core/db/modeldb.py
@@ -1,76 +1,11 @@
-import logging
-from abc import ABC, abstractmethod
-from typing import List, AsyncGenerator, Dict
-
-from arango.collection import StandardCollection
-
 from core.db.async_arangodb import AsyncArangoDB
-from core.event_bus import EventBus, CoreEvent
+from core.db.entitydb import EntityDb, EventEntityDb, ArangoEntityDb
 from core.model.model import Kind
-from core.model.typed_model import from_js, to_js
 
-log = logging.getLogger(__name__)
-
-
-class ModelDB(ABC):
-    @abstractmethod
-    def get_kinds(self) -> AsyncGenerator[Kind, None]:
-        pass
-
-    @abstractmethod
-    async def update_kinds(self, model: List[Kind]) -> None:
-        pass
-
-    @abstractmethod
-    async def delete_kind(self, model: Kind) -> None:
-        pass
+ModelDb = EntityDb[Kind]
+EventModelDb = EventEntityDb[Kind]
 
 
-class ArangoModelDB(ModelDB):
-    def __init__(self, db: AsyncArangoDB, model: str):
-        self.db = db
-        self.model = model
-
-    async def get_kinds(self) -> AsyncGenerator[Kind, None]:  # pylint: disable=invalid-overridden-method
-        with await self.db.all(self.model) as cursor:
-            for kind in cursor:
-                yield from_js(kind, Kind)  # type: ignore
-
-    async def update_kinds(self, model: List[Kind]) -> None:
-        await self.db.insert_many(self.model, [self.__to_doc(kind) for kind in model], overwrite=True)
-
-    async def delete_kind(self, model: Kind) -> None:
-        await self.db.delete(self.model, self.__to_doc(model))
-
-    async def create_update_schema(self) -> StandardCollection:
-        name = self.model
-        db = self.db
-        return db.collection(name) if await db.has_collection(name) else await db.create_collection(name)
-
-    async def wipe(self) -> bool:
-        return await self.db.truncate(self.model)
-
-    @staticmethod
-    def __to_doc(kind: Kind) -> Dict[str, object]:
-        js = to_js(kind)
-        js["_key"] = kind.fqn
-        return js
-
-
-class EventModelDB(ModelDB):
-    def __init__(self, db: ModelDB, event_bus: EventBus):
-        self.db = db
-        self.event_bus = event_bus
-
-    def get_kinds(self) -> AsyncGenerator[Kind, None]:
-        return self.db.get_kinds()
-
-    async def update_kinds(self, model: List[Kind]) -> None:
-        result = await self.db.update_kinds(model)
-        await self.event_bus.emit_event(CoreEvent.ModelUpdated, {"updated": [to_js(kind) for kind in model]})
-        return result
-
-    async def delete_kind(self, model: Kind) -> None:
-        result = await self.db.delete_kind(model)
-        await self.event_bus.emit_event(CoreEvent.ModelDeleted, to_js(model))
-        return result
+class ArangoModelDB(ArangoEntityDb[Kind]):
+    def __init__(self, db: AsyncArangoDB, collection: str):
+        super().__init__(db, collection, Kind, lambda k: k.fqn)  # type: ignore

--- a/keepercore/core/db/modeldb.py
+++ b/keepercore/core/db/modeldb.py
@@ -6,6 +6,5 @@ ModelDb = EntityDb[Kind]
 EventModelDb = EventEntityDb[Kind]
 
 
-class ArangoModelDB(ArangoEntityDb[Kind]):
-    def __init__(self, db: AsyncArangoDB, collection: str):
-        super().__init__(db, collection, Kind, lambda k: k.fqn)  # type: ignore
+def model_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[Kind]:
+    return ArangoEntityDb(db, collection, Kind, lambda k: k.fqn)  # type: ignore

--- a/keepercore/core/db/subscriberdb.py
+++ b/keepercore/core/db/subscriberdb.py
@@ -1,0 +1,11 @@
+from core.db.async_arangodb import AsyncArangoDB
+from core.db.entitydb import EntityDb, EventEntityDb, ArangoEntityDb
+from core.workflow.model import Subscriber
+
+SubscriberDb = EntityDb[Subscriber]
+EventSubscriberDb = EventEntityDb[Subscriber]
+
+
+class ArangoSubscriberDb(ArangoEntityDb[Subscriber]):
+    def __init__(self, db: AsyncArangoDB, collection: str):
+        super().__init__(db, collection, Subscriber, lambda k: k.id)

--- a/keepercore/core/db/subscriberdb.py
+++ b/keepercore/core/db/subscriberdb.py
@@ -7,4 +7,4 @@ EventSubscriberDb = EventEntityDb[Subscriber]
 
 
 def subscriber_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[Subscriber]:
-    return ArangoEntityDb(db, collection, Subscriber, lambda k: k.id)  # type: ignore
+    return ArangoEntityDb(db, collection, Subscriber, lambda k: k.id)

--- a/keepercore/core/db/subscriberdb.py
+++ b/keepercore/core/db/subscriberdb.py
@@ -6,6 +6,5 @@ SubscriberDb = EntityDb[Subscriber]
 EventSubscriberDb = EventEntityDb[Subscriber]
 
 
-class ArangoSubscriberDb(ArangoEntityDb[Subscriber]):
-    def __init__(self, db: AsyncArangoDB, collection: str):
-        super().__init__(db, collection, Subscriber, lambda k: k.id)
+def subscriber_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[Subscriber]:
+    return ArangoEntityDb(db, collection, Subscriber, lambda k: k.id)  # type: ignore

--- a/keepercore/core/event_bus.py
+++ b/keepercore/core/event_bus.py
@@ -22,8 +22,6 @@ class CoreEvent:
     BatchUpdateCommitted = "batch-update-committed"
     BatchUpdateAborted = "batch-update-aborted"
     GraphDBWiped = "graphdb-wiped"
-    ModelUpdated = "model-updated"
-    ModelDeleted = "model-deleted"
     WorkflowFinished = "workflow-finished"
 
 

--- a/keepercore/core/event_bus.py
+++ b/keepercore/core/event_bus.py
@@ -152,7 +152,10 @@ class EventBus:
     """
 
     def __init__(self) -> None:
+        # key is the channel name, value is the list of queues
         self.listeners: Dict[str, List[Queue[Message]]] = {}
+        # key is the subscriber id, value is the list of queue names
+        self.active_listener: dict[str, list[str]] = {}
 
     @contextmanager
     def subscribe(
@@ -192,6 +195,7 @@ class EventBus:
         if len(ch_list) == 0:
             raise AttributeError("Need at least one channel to subscribe to!")
         try:
+            self.active_listener[subscriber_id] = ch_list
             for channel in ch_list:
                 add_listener(channel)
             log.info(f"Listener {subscriber_id} added to following queues: {ch_list}")
@@ -200,6 +204,7 @@ class EventBus:
             log.info(f"Remove listener: {subscriber_id}")
             for channel in ch_list:
                 remove_listener(channel)
+            self.active_listener.pop(subscriber_id, None)
 
     async def emit_event(self, event_type: str, data: Json) -> None:
         return await self.emit(Event(event_type, data))

--- a/keepercore/core/model/model.py
+++ b/keepercore/core/model/model.py
@@ -183,7 +183,7 @@ class Kind(ABC):
             else:
                 raise TypeError(f"Unhandled runtime kind: {rk}")
         elif "fqn" in js and ("properties" in js or "bases" in js):
-            props: List[Property] = list(map(lambda p: from_js(p, Property), js.get("properties", [])))  # type: ignore
+            props = list(map(lambda p: from_js(p, Property), js.get("properties", [])))
             bases: List[str] = js.get("bases")  # type: ignore
             allow_unknown_props = js.get("allow_unknown_props", False)
             return Complex(js["fqn"], bases, props, allow_unknown_props)

--- a/keepercore/core/model/model_handler.py
+++ b/keepercore/core/model/model_handler.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Optional
 from plantuml import PlantUML
 
 from core.async_extensions import run_async
-from core.db.modeldb import ModelDB
+from core.db.modeldb import ModelDb
 from core.model.model import Model, Kind, Complex
 from core.util import exist
 
@@ -27,12 +27,12 @@ class ModelHandler(ABC):
 
 
 class ModelHandlerDB(ModelHandler):
-    def __init__(self, db: ModelDB, plantuml_server: str):
+    def __init__(self, db: ModelDb, plantuml_server: str):
         self.db = db
         self.plantuml_server = plantuml_server
 
     async def load_model(self) -> Model:
-        kinds = [kind async for kind in self.db.get_kinds()]
+        kinds = [kind async for kind in self.db.all()]
         return Model.from_kinds(list(kinds))
 
     async def uml_image(self, show_packages: Optional[List[str]] = None, output: str = "svg") -> bytes:
@@ -68,5 +68,5 @@ class ModelHandlerDB(ModelHandler):
         # make sure the update is valid
         updated = model.update_kinds(kinds)
         # store all updated kinds
-        await self.db.update_kinds(kinds)
+        await self.db.update_many(kinds)
         return updated

--- a/keepercore/core/model/typed_model.py
+++ b/keepercore/core/model/typed_model.py
@@ -5,6 +5,7 @@ from typing import Type, Any, Optional
 import jsons
 
 from core.types import Json
+from core.util import AnyT
 
 
 @functools.lru_cache(maxsize=1024)
@@ -23,17 +24,8 @@ def type_fqn(tpe: type) -> str:
     return tpe.__name__ if module is None or module == str.__class__.__module__ else module + "." + tpe.__name__
 
 
-def from_js(json: Optional[Any], clazz: Type[object]) -> object:
-    result = jsons.load(json, cls=clazz) if clazz != dict else json
-    # TODO: filter data that is not allowed to view
-    # try:
-    #     security_manager = SecurityManager.get()
-    #     for prop in properties(clazz).values():
-    #         if not security_manager.allowed_to_view(clazz, prop):
-    #             delattr(result, prop.name)
-    # except AttributeError:
-    #     pass
-    return result
+def from_js(json: Optional[Any], clazz: Type[AnyT]) -> AnyT:
+    return jsons.load(json, cls=clazz) if clazz != dict else json  # type: ignore
 
 
 def to_js(node: object) -> Json:

--- a/keepercore/core/static/api-doc.yaml
+++ b/keepercore/core/static/api-doc.yaml
@@ -17,6 +17,8 @@ tags:
       description: Endpoints to manipulate the desired data in the graph.
     - name: cli
       description: Endpoints to evaluate and execute cli commands
+    - name: subscriptions
+      description: Endpoints to manipulate event subscriptions
     - name: system
       description: Endpoints to get information about the system.
     - name: debug
@@ -341,12 +343,6 @@ paths:
                 - name: graph_id
                   in: path
                   description: "The identifier of the graph"
-                  required: true
-                  schema:
-                      type: string
-                - name: parent_node_id
-                  in: path
-                  description: "The identifier of the parent node"
                   required: true
                   schema:
                       type: string
@@ -927,7 +923,226 @@ paths:
                     description: ""
     # endregion
 
-    # region: cli
+    # region subscriptions
+
+    /subscribers:
+        get:
+            summary: "List all subscriptions"
+            description: "Get all subscriptions of all subscribers in the system"
+            tags:
+                - subscriptions
+            responses:
+                "200":
+                    description: "The list of all subscribers with all subscriptions"
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Subscriber"
+
+    /subscribers/for/{event_type}:
+        get:
+            summary: "List all subscribers for a given event type"
+            description: "Get all subscriptions of registered subscribers"
+            tags:
+                - subscriptions
+            parameters:
+                - name: event_type
+                  in: path
+                  description: "The type of message"
+                  required: true
+                  schema:
+                      type: string
+
+            responses:
+                "200":
+                    description: "The list of all subscribers which are subscribed"
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Subscriber"
+
+
+    /subscriber/{subscriber_id}:
+        get:
+            summary: "Get subscriber by id"
+            description: "Get the subscriber with a defined id."
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+
+            responses:
+                "200":
+                    description: "The subscriber"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscriber"
+                "404":
+                    description: "No subscriber found"
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                                example: No subscriber with this id
+        put:
+            summary: "Define subscriber with all subscriptions"
+            description: |
+                Define or redefine a subscriber with all subscriptions.
+                In case the subscriber does not exist, it is created.
+                In case the subscriber exist, all subscriptions get replaced.
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The list of all subscriptions."
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/Subscription"
+            responses:
+                "200":
+                    description: "The subscriber"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscriber"
+        delete:
+            summary: "Delete by id"
+            description: "Delete the subscriber with a defined id."
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+
+            responses:
+                "204":
+                    description: "no content"
+
+
+
+    /subscriber/{subscriber_id}/{event_type}:
+        post:
+            summary: "Add subscription to subscriber"
+            description: "Add a specific subscription to a subscriber."
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+                - name: event_type
+                  in: path
+                  description: "The action event type."
+                  required: true
+                  schema:
+                      type: string
+                - name: timeout
+                  in: query
+                  required: false
+                  description: |
+                      This is the duration in seconds this subscriber has time to execute the action.
+                      After this time the sender assumes a failure and rejects the result of this actor.
+                  schema:
+                      type: number
+                      default: 60
+                - name: wait_for_completion
+                  in: query
+                  required: false
+                  description: |
+                      If an action is sent to this subscriber, the event sender should wait until this
+                      subscriber has processed the message and send a done message.
+                      This is the expected behaviour of every actor and defaults to true.
+                  schema:
+                      type: boolean
+                      default: true
+            responses:
+                "200":
+                    description: "The subscriber"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscriber"
+        delete:
+            summary: "Delete a specific subscription from the subscriber."
+            description: "Delete a specific subscription from the subscriber."
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+                - name: event_type
+                  in: path
+                  description: "The action event type."
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: "The subscriber"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscriber"
+
+    /subscriber/{subscriber_id}/handle:
+        get:
+            summary: "Listen to registered events of given subscriber"
+            description: |
+                This endpoint expects a web-socket connection!
+                The connection to this endpoint will never be closed.
+                All action events of the system this subscriber has registerd will be send to this
+                connection.
+            tags:
+                - subscriptions
+            parameters:
+                - name: subscriber_id
+                  in: path
+                  description: "The identifier of the subscriber"
+                  required: true
+                  schema:
+                      type: string
+
+            responses:
+                "404":
+                    description: "No subscriber found"
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                                example: No subscriber with this id
+    # endregion
+
+    # region cli
     /cli/evaluate:
         post:
             summary: "Evaluate a cli command"
@@ -1017,6 +1232,38 @@ paths:
 
 components:
     schemas:
+        Subscriber:
+            description: "A subscriber has a unique name and a list of subscriptions"
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: "The identifier of this subscriber"
+                subscriptions:
+                    type: object
+                    description: "The dictionary of subscriptions, where the key is the message type"
+                    additionalProperties:
+                        $ref: "#/components/schemas/Subscription"
+        Subscription:
+            description: "The definition of an action subscription"
+            type: object
+            properties:
+                message_type:
+                    type: string
+                    description: "The name of the action to listen to"
+                wait_for_completion:
+                    type: boolean
+                    description: |
+                        If an action is sent to this subscriber, the event sender should wait until this
+                        subscriber has processed the message and send a done message.
+                        This is the expected behaviour of every actor and defaults to true.
+                    default: true
+                timeout:
+                    type: number
+                    description: |
+                        This is the duration in seconds this subscriber has time to execute the action.
+                        After this time the sender assumes a failure and rejects the result of this actor.
+                    default: 60
         Aggregated:
             description: "The result of the aggregation. The properties depend on the aggregation function."
             type: object
@@ -1357,6 +1604,3 @@ components:
                     type: object
                     description: "All binding variables for this query"
                     additionalProperties: true
-
-
-

--- a/keepercore/core/web/api.py
+++ b/keepercore/core/web/api.py
@@ -30,7 +30,7 @@ from core.types import Json
 from core.model.model_handler import ModelHandler
 from core.model.typed_model import to_js, from_js, to_js_str
 from core.query.query_parser import parse_query
-from core.workflow.subscribers import SubscriptionHandler
+from core.workflow.subscribers import SubscriptionHandler, Subscription
 from core.workflow.workflows import WorkflowHandler
 
 log = logging.getLogger(__name__)
@@ -102,13 +102,15 @@ class Api:
                 web.post("/graph/{graph_id}/desired/query/graph", partial(self.query_graph_stream, d, rd)),
                 web.post("/graph/{graph_id}/desired/query/aggregate", partial(self.query_aggregation, d)),
                 # Subscriptions
-                web.get("/subscriptions", self.list_all_subscriptions),
-                web.get("/subscriptions/for/{event_type}", self.list_subscription_for_event),
+                web.get("/subscribers", self.list_all_subscriptions),
+                web.get("/subscribers/for/{event_type}", self.list_subscription_for_event),
                 # Subscription
-                web.get("/subscription/{subscriber_id}", self.list_subscriptions),
-                web.post("/subscription/{subscriber_id}/{event_type}", self.add_subscription),
-                web.delete("/subscription/{subscriber_id}/{event_type}", self.delete_subscription),
-                web.get("/subscription/{subscriber_id}/handle", self.handle_subscribed),
+                web.get("/subscriber/{subscriber_id}", self.get_subscriber),
+                web.put("/subscriber/{subscriber_id}", self.update_subscriber),
+                web.delete("/subscriber/{subscriber_id}", self.delete_subscriber),
+                web.post("/subscriber/{subscriber_id}/{event_type}", self.add_subscription),
+                web.delete("/subscriber/{subscriber_id}/{event_type}", self.delete_subscription),
+                web.get("/subscriber/{subscriber_id}/handle", self.handle_subscribed),
                 # CLI
                 web.post("/cli/evaluate", self.evaluate),
                 web.post("/cli/execute", self.execute),
@@ -124,7 +126,7 @@ class Api:
         subscribers = await self.subscription_handler.all_subscribers()
         return web.json_response(to_js(subscribers))
 
-    async def list_subscriptions(self, request: Request) -> StreamResponse:
+    async def get_subscriber(self, request: Request) -> StreamResponse:
         subscriber_id = request.match_info["subscriber_id"]
         subscriber = await self.subscription_handler.get_subscriber(subscriber_id)
         return self.optional_json(subscriber, f"No subscriber with id {subscriber_id}")
@@ -134,10 +136,22 @@ class Api:
         subscribers = await self.subscription_handler.list_subscriber_for(event_type)
         return web.json_response(to_js(subscribers))
 
+    async def update_subscriber(self, request: Request) -> StreamResponse:
+        subscriber_id = request.match_info["subscriber_id"]
+        body = await request.json()
+        subscriptions = from_js(body, List[Subscription])
+        sub = await self.subscription_handler.update_subscriptions(subscriber_id, subscriptions)
+        return web.json_response(to_js(sub))
+
+    async def delete_subscriber(self, request: Request) -> StreamResponse:
+        subscriber_id = request.match_info["subscriber_id"]
+        await self.subscription_handler.remove_subscriber(subscriber_id)
+        return web.HTTPNoContent()
+
     async def add_subscription(self, request: Request) -> StreamResponse:
         subscriber_id = request.match_info["subscriber_id"]
         event_type = request.match_info["event_type"]
-        timeout = timedelta(seconds=int(request.query.get("timeout", "600")))
+        timeout = timedelta(seconds=int(request.query.get("timeout", "60")))
         wait_for_completion = request.query.get("wait_for_completion", "true").lower() != "false"
         sub = await self.subscription_handler.add_subscription(subscriber_id, event_type, wait_for_completion, timeout)
         return web.json_response(to_js(sub))
@@ -181,7 +195,7 @@ class Api:
                         log.info(f"Incoming message: type={msg.type} data={msg.data} extra={msg.extra}")
                         js = json.loads(msg.data)
                         js["subscriber_id"] = listener_id
-                        message: Message = from_js(js, Message)  # type: ignore
+                        message: Message = from_js(js, Message)
                         if isinstance(message, Action):
                             raise AttributeError("Actors should not emit action messages. ")
                         elif isinstance(message, ActionDone):
@@ -227,7 +241,7 @@ class Api:
 
     async def update_model(self, request: Request) -> StreamResponse:
         js = await request.json()
-        kinds: List[Kind] = from_js(js, List[Kind])  # type: ignore
+        kinds: List[Kind] = from_js(js, List[Kind])
         model = await self.model_handler.update_model(kinds)
         return web.json_response(to_js(model))
 

--- a/keepercore/core/web/api.py
+++ b/keepercore/core/web/api.py
@@ -30,7 +30,8 @@ from core.types import Json
 from core.model.model_handler import ModelHandler
 from core.model.typed_model import to_js, from_js, to_js_str
 from core.query.query_parser import parse_query
-from core.workflow.subscribers import SubscriptionHandler, Subscription
+from core.workflow.model import Subscription
+from core.workflow.subscribers import SubscriptionHandler
 from core.workflow.workflows import WorkflowHandler
 
 log = logging.getLogger(__name__)
@@ -172,7 +173,7 @@ class Api:
             return web.HTTPNotFound(text=f"No subscriber with this id: {subscriber_id} or no subscriptions")
 
     async def redirect_to_ui(self, request: Request) -> StreamResponse:
-        raise web.HTTPFound("/static/index.html")
+        raise web.HTTPFound("api-doc")
 
     async def handle_events(self, request: Request) -> StreamResponse:
         show = request.query["show"].split(",") if "show" in request.query else ["*"]

--- a/keepercore/core/workflow/model.py
+++ b/keepercore/core/workflow/model.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+from datetime import timedelta
+
+from abc import ABC
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class Subscription(ABC):
+    message_type: str
+    wait_for_completion: bool = field(default=True)
+    timeout: timedelta = field(default=timedelta(seconds=60))
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class Subscriber(ABC):
+    id: str
+    subscriptions: dict[str, Subscription]
+
+    @staticmethod
+    def from_list(uid: str, subscriptions: list[Subscription]) -> Subscriber:
+        return Subscriber(uid, {s.message_type: s for s in subscriptions})
+
+    def add_subscription(self, message_type: str, wait_for_completion: bool, timeout: timedelta) -> Subscriber:
+        subscription = Subscription(message_type, wait_for_completion, timeout)
+        existing = self.subscriptions.get(message_type)
+        if existing == subscription:
+            return self
+        else:
+            return Subscriber(self.id, self.subscriptions | {subscription.message_type: subscription})
+
+    def remove_subscription(self, message_type: str) -> Subscriber:
+        subs = self.subscriptions.copy()
+        subs.pop(message_type, None)
+        return Subscriber(self.id, subs)
+
+    def __contains__(self, message_type: str) -> bool:
+        return message_type in self.subscriptions
+
+    def __getitem__(self, message_type: str) -> Subscription:
+        return self.subscriptions[message_type]

--- a/keepercore/core/workflow/subscribers.py
+++ b/keepercore/core/workflow/subscribers.py
@@ -1,58 +1,27 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from collections import defaultdict
 from datetime import timedelta
 from typing import List, Dict, Optional, Iterable
 
-from dataclasses import dataclass, field
+from core.db.subscriberdb import SubscriberDb
+from core.workflow.model import Subscriber, Subscription
+
+log = logging.getLogger(__name__)
 
 
-@dataclass(unsafe_hash=True, frozen=True)
-class Subscription(ABC):
-    message_type: str
-    wait_for_completion: bool = field(default=True)
-    timeout: timedelta = field(default=timedelta(seconds=60))
-
-
-@dataclass(unsafe_hash=True, frozen=True)
-class Subscriber(ABC):
-    id: str
-    subscriptions: dict[str, Subscription]
-
-    @staticmethod
-    def from_list(uid: str, subscriptions: list[Subscription]) -> Subscriber:
-        return Subscriber(uid, {s.message_type: s for s in subscriptions})
-
-    def add_subscription(self, message_type: str, wait_for_completion: bool, timeout: timedelta) -> Subscriber:
-        subscription = Subscription(message_type, wait_for_completion, timeout)
-        existing = self.subscriptions.get(message_type)
-        if existing == subscription:
-            return self
-        else:
-            return Subscriber(self.id, self.subscriptions | {subscription.message_type: subscription})
-
-    def remove_subscription(self, message_type: str) -> Subscriber:
-        subs = self.subscriptions.copy()
-        subs.pop(message_type, None)
-        return Subscriber(self.id, subs)
-
-    def __contains__(self, message_type: str) -> bool:
-        return message_type in self.subscriptions
-
-    def __getitem__(self, message_type: str) -> Subscription:
-        return self.subscriptions[message_type]
-
-
-# TODO: add database handling
 class SubscriptionHandler(ABC):
-    def __init__(self) -> None:
+    def __init__(self, db: SubscriberDb) -> None:
         # subscriber by subscriber id
+        self.db = db
         self.subscribers_by_id: Dict[str, Subscriber] = {}
         self.subscribers_by_event: Dict[str, List[Subscriber]] = {}
 
     async def start(self) -> None:
-        return None
+        await self.__load_from_db()
+        log.info(f"Loaded {len(self.subscribers_by_id)} subscribers for {len(self.subscribers_by_event)} events")
 
     async def all_subscribers(self) -> Iterable[Subscriber]:
         return self.subscribers_by_id.values()
@@ -69,32 +38,43 @@ class SubscriptionHandler(ABC):
         existing = self.subscribers_by_id.get(subscriber_id, Subscriber(subscriber_id, {}))
         updated = existing.add_subscription(event_type, wait_for_completion, timeout)
         if existing != updated:
-            self.subscribers_by_id[subscriber_id] = updated
-            self.subscribers_by_event = self.update_subscriber_by_event(self.subscribers_by_id.values())
+            log.info(f"Subscriber {subscriber_id}: add subscription={event_type} ({wait_for_completion}, {timeout})")
+            await self.db.update(updated)
+            await self.__load_from_db()
         return updated
 
     async def remove_subscription(self, subscriber_id: str, event_type: str) -> Subscriber:
         existing = self.subscribers_by_id.get(subscriber_id, Subscriber(subscriber_id, {}))
         updated = existing.remove_subscription(event_type)
         if existing != updated:
-            self.subscribers_by_id[subscriber_id] = updated
-            self.subscribers_by_event = self.update_subscriber_by_event(self.subscribers_by_id.values())
+            log.info(f"Subscriber {subscriber_id}: remove subscription={event_type}")
+            if updated.subscriptions:
+                await self.db.update(updated)
+            else:
+                await self.db.delete(subscriber_id)
+            await self.__load_from_db()
         return updated
 
     async def update_subscriptions(self, subscriber_id: str, subscriptions: list[Subscription]) -> Subscriber:
         existing = self.subscribers_by_id.get(subscriber_id, None)
         updated = Subscriber.from_list(subscriber_id, subscriptions)
         if existing != updated:
-            self.subscribers_by_id[subscriber_id] = updated
-            self.subscribers_by_event = self.update_subscriber_by_event(self.subscribers_by_id.values())
+            log.info(f"Subscriber {subscriber_id}: update all subscriptions={subscriptions}")
+            await self.db.update(updated)
+            await self.__load_from_db()
         return updated
 
     async def remove_subscriber(self, subscriber_id: str) -> Optional[Subscriber]:
         existing = self.subscribers_by_id.get(subscriber_id, None)
         if existing:
-            self.subscribers_by_id.pop(subscriber_id, None)
-            self.subscribers_by_event = self.update_subscriber_by_event(self.subscribers_by_id.values())
+            log.info(f"Subscriber {subscriber_id}: remove subscriber")
+            await self.db.delete(subscriber_id)
+            await self.__load_from_db()
         return existing
+
+    async def __load_from_db(self) -> None:
+        self.subscribers_by_id = {s.id: s async for s in self.db.all()}
+        self.subscribers_by_event = self.update_subscriber_by_event(self.subscribers_by_id.values())
 
     @staticmethod
     def update_subscriber_by_event(subscribers: Iterable[Subscriber]) -> Dict[str, List[Subscriber]]:

--- a/keepercore/core/workflow/workflows.py
+++ b/keepercore/core/workflow/workflows.py
@@ -15,7 +15,8 @@ from core.event_bus import EventBus, Event, Action, ActionDone, Message, ActionE
 from core.types import Json
 from core.util import first, Periodic, interleave, empty, exist, group_by
 from core.workflow.scheduler import Scheduler
-from core.workflow.subscribers import SubscriptionHandler, Subscriber
+from core.workflow.subscribers import SubscriptionHandler
+from core.workflow.model import Subscriber
 
 log = logging.getLogger(__name__)
 

--- a/keepercore/tests/core/db/entitydb.py
+++ b/keepercore/tests/core/db/entitydb.py
@@ -1,0 +1,37 @@
+from typing import Union, Optional, List, AsyncGenerator, Type, Callable
+
+
+from core.db.entitydb import EntityDb, T
+from core.model.typed_model import from_js, to_js
+from core.types import Json
+
+
+class InMemoryDb(EntityDb[T]):
+    def __init__(self, t_type: Type[T], key_fn: Callable[[T], str]):
+        self.items: dict[str, Json] = {}
+        self.t_type = t_type
+        self.key_fn = key_fn
+
+    async def all(self) -> AsyncGenerator[T, None]:
+        for js in self.items.values():
+            yield from_js(js, self.t_type)
+
+    async def update_many(self, elements: List[T]) -> None:
+        for elem in elements:
+            key = self.key_fn(elem)
+            self.items[key] = to_js(key)
+
+    async def get(self, key: str) -> Optional[T]:
+        js = self.items.get(key)
+        return from_js(js, self.t_type) if js else None
+
+    async def update(self, t: T) -> T:
+        self.items[self.key_fn(t)] = to_js(t)
+        return t
+
+    async def delete(self, key_or_object: Union[str, T]) -> None:
+        key = key_or_object if isinstance(key_or_object, str) else self.key_fn(key_or_object)
+        self.items.pop(key, None)
+
+    async def create_update_schema(self) -> None:
+        pass

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -397,4 +397,4 @@ def to_json(obj: BaseResource) -> Json:
 
 
 def to_foo(json: Json) -> Foo:
-    return from_js(json, Foo)  # type: ignore
+    return from_js(json, Foo)

--- a/keepercore/tests/core/db/modeldb_test.py
+++ b/keepercore/tests/core/db/modeldb_test.py
@@ -4,8 +4,9 @@ from typing import List
 import pytest
 from arango.database import StandardDatabase
 
+from core.db import modeldb
 from core.db.async_arangodb import AsyncArangoDB
-from core.db.modeldb import ArangoModelDB, ModelDb, EventModelDb
+from core.db.modeldb import ModelDb, EventModelDb
 from core.db.entitydb import EventEntityDb
 from core.event_bus import EventBus, Message
 from core.model.model import Complex, Property, StringKind, NumberKind, BooleanKind, Kind
@@ -56,7 +57,7 @@ def test_model() -> List[Kind]:
 @pytest.fixture
 async def model_db(test_db: StandardDatabase) -> ModelDb:
     async_db = AsyncArangoDB(test_db)
-    model_db = ArangoModelDB(async_db, "model")
+    model_db = modeldb.model_db(async_db, "model")
     await model_db.create_update_schema()
     await model_db.wipe()
     return model_db

--- a/keepercore/tests/core/db/subscriberdb_test.py
+++ b/keepercore/tests/core/db/subscriberdb_test.py
@@ -1,0 +1,78 @@
+import asyncio
+from typing import List
+import pytest
+from arango.database import StandardDatabase
+from core.db.async_arangodb import AsyncArangoDB
+from core.db.entitydb import EventEntityDb
+from core.db.subscriberdb import SubscriberDb, ArangoSubscriberDb, EventSubscriberDb
+from core.event_bus import EventBus, Message
+from core.workflow.model import Subscriber, Subscription
+
+# noinspection PyUnresolvedReferences
+from tests.core.event_bus_test import event_bus, all_events
+
+# noinspection PyUnresolvedReferences
+from tests.core.db.graphdb_test import test_db
+
+
+@pytest.fixture
+async def subscriber_db(test_db: StandardDatabase) -> SubscriberDb:
+    async_db = AsyncArangoDB(test_db)
+    subscriber_db = ArangoSubscriberDb(async_db, "subscriber")
+    await subscriber_db.create_update_schema()
+    await subscriber_db.wipe()
+    return subscriber_db
+
+
+@pytest.fixture
+def event_db(subscriber_db: SubscriberDb, event_bus: EventBus) -> EventSubscriberDb:
+    return EventEntityDb(subscriber_db, event_bus, "subscriber")
+
+
+@pytest.fixture
+def subscribers() -> List[Subscriber]:
+    subs = [Subscription("foo", True) for _ in range(0, 10)]
+    return [Subscriber.from_list(str(a), subs) for a in range(0, 10)]
+
+
+@pytest.mark.asyncio
+async def test_load(subscriber_db: SubscriberDb, subscribers: List[Subscriber]) -> None:
+    await subscriber_db.update_many(subscribers)
+    loaded = [sub async for sub in subscriber_db.all()]
+    assert subscribers.sort() == loaded.sort()
+
+
+@pytest.mark.asyncio
+async def test_update(subscriber_db: SubscriberDb, subscribers: List[Subscriber]) -> None:
+    # multiple updates should work as expected
+    await subscriber_db.update_many(subscribers)
+    await subscriber_db.update_many(subscribers)
+    await subscriber_db.update_many(subscribers)
+    loaded = [sub async for sub in subscriber_db.all()]
+    assert subscribers.sort() == loaded.sort()
+
+
+@pytest.mark.asyncio
+async def test_delete(subscriber_db: SubscriberDb, subscribers: List[Subscriber]) -> None:
+    await subscriber_db.update_many(subscribers)
+    remaining = list(subscribers)
+    for _ in subscribers:
+        sub = remaining.pop()
+        await subscriber_db.delete(sub)
+        loaded = [sub async for sub in subscriber_db.all()]
+        assert remaining.sort() == loaded.sort()
+    assert len([sub async for sub in subscriber_db.all()]) == 0
+
+
+@pytest.mark.asyncio
+async def test_events(event_db: EventSubscriberDb, subscribers: List[Subscriber], all_events: List[Message]) -> None:
+    # 2 times update
+    await event_db.update_many(subscribers)
+    await event_db.update_many(subscribers)
+    # 6 times delete
+    for sub in subscribers:
+        await event_db.delete(sub)
+    # make sure all events will arrive
+    await asyncio.sleep(0.1)
+    # ensure the correct count and order of events
+    assert [a.message_type for a in all_events] == ["subscriber-updated-many"] * 2 + ["subscriber-deleted"] * 10

--- a/keepercore/tests/core/db/subscriberdb_test.py
+++ b/keepercore/tests/core/db/subscriberdb_test.py
@@ -2,9 +2,11 @@ import asyncio
 from typing import List
 import pytest
 from arango.database import StandardDatabase
+
+from core.db import subscriberdb
 from core.db.async_arangodb import AsyncArangoDB
 from core.db.entitydb import EventEntityDb
-from core.db.subscriberdb import SubscriberDb, ArangoSubscriberDb, EventSubscriberDb
+from core.db.subscriberdb import SubscriberDb, EventSubscriberDb
 from core.event_bus import EventBus, Message
 from core.workflow.model import Subscriber, Subscription
 
@@ -18,7 +20,7 @@ from tests.core.db.graphdb_test import test_db
 @pytest.fixture
 async def subscriber_db(test_db: StandardDatabase) -> SubscriberDb:
     async_db = AsyncArangoDB(test_db)
-    subscriber_db = ArangoSubscriberDb(async_db, "subscriber")
+    subscriber_db = subscriberdb.subscriber_db(async_db, "subscriber")
     await subscriber_db.create_update_schema()
     await subscriber_db.wipe()
     return subscriber_db

--- a/keepercore/tests/core/workflow/subscribers_test.py
+++ b/keepercore/tests/core/workflow/subscribers_test.py
@@ -5,6 +5,7 @@ from deepdiff import DeepDiff
 from pytest import fixture, mark
 
 from core.db.subscriberdb import SubscriberDb
+from core.event_bus import EventBus
 from tests.core.db.entitydb import InMemoryDb
 from core.model.typed_model import to_js, from_js
 from core.workflow.model import Subscription, Subscriber
@@ -18,7 +19,7 @@ def in_mem_db() -> SubscriberDb:
 
 @fixture
 async def handler(in_mem_db: SubscriberDb) -> SubscriptionHandler:
-    result = SubscriptionHandler(in_mem_db)
+    result = SubscriptionHandler(in_mem_db, EventBus())
     await result.add_subscription("sub_1", "test", True, timedelta(seconds=3))
     return result
 

--- a/keepercore/tests/core/workflow/workflows_test.py
+++ b/keepercore/tests/core/workflow/workflows_test.py
@@ -60,8 +60,8 @@ def workflow_instance(
     sub1 = Subscription("start_collect", True, td)
     sub2 = Subscription("collect", True, td)
     sub3 = Subscription("collect_done", True, td)
-    s1 = Subscriber("s1", [sub1, sub2, sub3])
-    s2 = Subscriber("s2", [sub2, sub3])
+    s1 = Subscriber.from_list("s1", [sub1, sub2, sub3])
+    s2 = Subscriber.from_list("s2", [sub2, sub3])
     subscriptions = {"start_collect": [s1], "collect": [s1, s2], "collect_done": [s1, s2]}
     w, _ = WorkflowInstance.empty(test_workflow, subscriptions)
     w.received_messages = [

--- a/keepercore/tests/core/workflow/workflows_test.py
+++ b/keepercore/tests/core/workflow/workflows_test.py
@@ -26,9 +26,9 @@ from tests.core.event_bus_test import event_bus
 
 
 @fixture
-async def subscription_handler() -> SubscriptionHandler:
+async def subscription_handler(event_bus: EventBus) -> SubscriptionHandler:
     in_mem = InMemoryDb(Subscriber, lambda x: x.id)
-    result = SubscriptionHandler(in_mem)
+    result = SubscriptionHandler(in_mem, event_bus)
     await result.add_subscription("sub_1", "test", True, timedelta(seconds=3))
     return result
 

--- a/keepercore/tests/core/workflow/workflows_test.py
+++ b/keepercore/tests/core/workflow/workflows_test.py
@@ -3,9 +3,11 @@ from typing import Tuple, Dict, List
 
 from pytest import fixture
 
+from tests.core.db.entitydb import InMemoryDb
 from core.event_bus import EventBus, Action, ActionDone, ActionError, Event
 from core.workflow.scheduler import Scheduler
-from core.workflow.subscribers import SubscriptionHandler, Subscriber, Subscription
+from core.workflow.subscribers import SubscriptionHandler
+from core.workflow.model import Subscriber, Subscription
 from core.workflow.workflows import (
     WorkflowHandler,
     Workflow,
@@ -25,7 +27,8 @@ from tests.core.event_bus_test import event_bus
 
 @fixture
 async def subscription_handler() -> SubscriptionHandler:
-    result = SubscriptionHandler()
+    in_mem = InMemoryDb(Subscriber, lambda x: x.id)
+    result = SubscriptionHandler(in_mem)
     await result.add_subscription("sub_1", "test", True, timedelta(seconds=3))
     return result
 


### PR DESCRIPTION
This PR introduces durable subscriptions: all subscriptions are stored in a database and will be loaded when the service restarts. 

A subscription is automatically removed, when a client subscribes to events, but does not connect to handle those events.

- endpoint is added to define all subscriptions of one handler with one request (`PUT  /subscriber/{subscriber_id}`)
- endpoint is added to remove one subscriber with all subscriptions (`DELETE  /subscriber/{subscriber_id}`)
- it is checked, that there is only one active listener per subscriber_id
- api-documentation for the subscriber endpoints