### PR TITLE
[keepeercore] Fix echo parse_arg

### DIFF
--- a/keepercore/core/cli/command.py
+++ b/keepercore/core/cli/command.py
@@ -57,9 +57,7 @@ class EchoSource(CLISource):
             elements = [js]
         else:
             raise AttributeError(f"Echo does not understand {arg}.")
-
-        for element in elements:
-            yield element
+        return stream.iterate(elements)  # type: ignore
 
 
 class MatchSource(CLISource):

--- a/keepercore/core/cli/command.py
+++ b/keepercore/core/cli/command.py
@@ -45,7 +45,12 @@ class EchoSource(CLISource):
         return "Parse json and pass parsed objects to the output stream."
 
     async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
-        js = json.loads(arg if arg else "")
+        arg_str = arg if arg else ""
+        js_str = arg_str if arg_str.strip() else '""'
+        try:
+            js = json.loads(js_str)
+        except Exception:
+            js = js_str
         if isinstance(js, list):
             elements = js
         elif isinstance(js, (str, int, float, bool, dict)):

--- a/keepercore/tests/core/cli/command_test.py
+++ b/keepercore/tests/core/cli/command_test.py
@@ -29,12 +29,23 @@ def echo_source() -> str:
 
 @pytest.mark.asyncio
 async def test_echo_source(cli: CLI, sink: Sink[List[JsonElement]]) -> None:
+    # no arg passed to echo
+    result = await cli.execute_cli_command("echo", sink)
+    assert result[0] == [""]
+
+    # simple string passed to echo
+    result = await cli.execute_cli_command("echo this is a string", sink)
+    assert result[0] == ["this is a string"]
+
+    # json object passed to echo
+    result = await cli.execute_cli_command('echo {"a": 1}', sink)
+    assert result[0] == [{"a": 1}]
+
+    # json array passed to echo
     result = await cli.execute_cli_command('echo [{"a": 1}, {"b":2}]', sink)
     assert result[0] == [{"a": 1}, {"b": 2}]
 
-    result = await cli.execute_cli_command("echo [1,2,3,4]", sink)
-    assert result[0] == [1, 2, 3, 4]
-
+    # json string passed to echo
     result = await cli.execute_cli_command('echo "foo bla bar"', sink)
     assert result[0] == ["foo bla bar"]
 


### PR DESCRIPTION
Fixes #103

Mental mismatch:
```
async def foo() -> AsyncGenerator[int, None]:
    raise Exception("")
    for a in range(0, 100):
        yield a


async def bla() -> AsyncGenerator[int, None]:
    async def gen() -> AsyncGenerator[int, None]:
        for a in range(0, 100):
            yield a

    raise Exception("")
    return gen()
```

foo() and bla() both return the same result.
bla() needs to be awaited and throws an exception when called while foo() would throw an exception,
when the generator is consumed.

This has been the case with echo: so parse_arg did not throw, but execute did.

I also changed the implementation of echo to allow empty string or any other value as string, if it can not be parsed as json.