### PR TITLE
[keepercore] add endpoints to query all sections

### DIFF
--- a/keepercore/core/db/arangodb_functions.py
+++ b/keepercore/core/db/arangodb_functions.py
@@ -32,7 +32,8 @@ def in_subnet(cursor: str, bind_vars: Json, fn: FunctionTerm, model: QueryModel)
     expected = int(network.network_address) & mask
     length = str(len(bind_vars))
     bind_vars[length] = expected
-    return f"BIT_AND(IPV4_TO_NUMBER({cursor}.{model.query_section}.{fn.property_path}), {mask}) == @{length}"
+    section_dot = f"{model.query_section}." if model.query_section else ""
+    return f"BIT_AND(IPV4_TO_NUMBER({cursor}.{section_dot}{fn.property_path}), {mask}) == @{length}"
 
 
 def as_arangodb_function(cursor: str, bind_vars: Json, fn: FunctionTerm, model: QueryModel) -> str:

--- a/keepercore/core/db/model.py
+++ b/keepercore/core/db/model.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 from abc import ABC
-from typing import Optional, List, Union, Any
+from typing import Optional, Any
 
 from core.model.model import Model
 from core.query.model import Query
 
 
 class QueryModel(ABC):
-    def __init__(
-        self, query: Query, model: Model, query_section: str, return_section: Optional[Union[str, List[str]]] = None
-    ):
+    def __init__(self, query: Query, model: Model, query_section: Optional[str]):
         self.query = query
         self.model = model
         self.query_section = query_section
-        self.return_section = return_section if return_section is not None else query_section
 
 
 class GraphUpdate(ABC):

--- a/keepercore/core/static/api-doc.yaml
+++ b/keepercore/core/static/api-doc.yaml
@@ -15,6 +15,8 @@ tags:
       description: Endpoints to manipulate the reported data in the graph.
     - name: graph_desired
       description: Endpoints to manipulate the desired data in the graph.
+    - name: graph_all
+      description: Endpoints to query all sections of the graph
     - name: cli
       description: Endpoints to evaluate and execute cli commands
     - name: subscriptions
@@ -151,6 +153,218 @@ paths:
                             example: "Graph deleted."
     # endregion
 
+    # region graph no section
+    /graph/{graph_id}/query:
+        post:
+            summary: "Query this graph"
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+            tags:
+                - graph_all
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+                - name: format
+                  in: header
+                  description: "The format of the result to return"
+                  required: true
+                  schema:
+                      type: string
+                      enum:
+                          - graph
+                          - list
+                          - cytoscape
+            requestBody:
+                description: "The query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: isinstance("graph_root") and reported.name=="root" -[0:1]->
+            responses:
+                "200":
+                    description: "The result of this query in the defined format"
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/Graph"
+                                    - type: array
+                                      items:
+                                          $ref: "#/components/schemas/Node"
+                        application/x-ndjson:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/NodeInGraph"
+                                    - $ref: "#/components/schemas/Edge"
+    /graph/{graph_id}/query/raw:
+        post:
+            summary: "Transform the query into the raw database query"
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+            tags:
+                - debug
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: isinstance("graph_root") and reported.name=="root" -[0:1]->
+            responses:
+                "200":
+                    description: "Returns the query as performed by the database."
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RawQuery"
+    /graph/{graph_id}/query/list:
+        post:
+            summary: "Query the graph and return all nodes as list (this will not contain any edges)"
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+            tags:
+                - graph_all
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: isinstance("graph_root") and reported.name=="root" -[0:1]->
+            responses:
+                "200":
+                    description: "The result of this query in the defined format"
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Node"
+                        application/x-ndjson:
+                            schema:
+                                $ref: "#/components/schemas/Node"
+    /graph/{graph_id}/query/graph:
+        post:
+            summary: "Query the graph and return the resulting graph."
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+            tags:
+                - graph_all
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: isinstance("graph_root") and reported.name=="root" -[0:1]->
+            responses:
+                "200":
+                    description: "The result of this query in the defined format"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Graph"
+                        application/x-ndjson:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/NodeInGraph"
+                                    - $ref: "#/components/schemas/Edge"
+    /graph/{graph_id}/query/aggregate:
+        post:
+            summary: "Query the aggregate function on the specified graph and return the aggregation result."
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+            tags:
+                - graph_all
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The aggregation query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: |
+                                aggregate(kind: count(id) as nodes): isinstance("node")
+            responses:
+                "200":
+                    description: "The result of this query in the defined format"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Aggregated"
+                        application/x-ndjson:
+                            schema:
+                                $ref: "#/components/schemas/Aggregated"
+    /graph/{graph_id}/query/explain:
+        post:
+            summary: "Explain the query execution plan"
+            description: |
+                Query the graph by all sections. This means that properties have to be prefixed by the section name.
+                Example: reported.age>23 and desired.clean==true and metadata.version==2
+
+            tags:
+                - debug
+            parameters:
+                - name: graph_id
+                  in: path
+                  description: "The identifier of the graph"
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: "The query to perform"
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: isinstance("graph_root") and reported.name=="root" -[0:1]->
+            responses:
+                "200":
+                    description: "The execution plan of the database"
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                additionalProperties: true
+    # endregion
+
     # region graph reported
     /graph/{graph_id}/reported/search:
         get:
@@ -244,7 +458,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Node"
-
         patch:
             summary: "Update a node with the given node id"
             tags:
@@ -480,7 +693,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="root" -[0:1]->
+                            example: isinstance("graph_root") and name=="root" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -515,7 +728,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="root" -[0:1]->
+                            example: isinstance("graph_root") and name=="root" -[0:1]->
             responses:
                 "200":
                     description: "Returns the query as performed by the database."
@@ -541,7 +754,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="root" -[0:1]->
+                            example: isinstance("graph_root") and name=="root" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -572,7 +785,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="root" -[0:1]->
+                            example: isinstance("graph_root") and name=="root" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -634,7 +847,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="root" -[0:1]->
+                            example: isinstance("graph_root") and name=="root" -[0:1]->
             responses:
                 "200":
                     description: "The execution plan of the database"
@@ -735,7 +948,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="Batman" -[0:1]->
+                            example: isinstance("graph_root") and name=="Batman" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -770,7 +983,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="Batman" -[0:1]->
+                            example: isinstance("graph_root") and name=="Batman" -[0:1]->
             responses:
                 "200":
                     description: "Returns the query as performed by the database."
@@ -796,7 +1009,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="Batman" -[0:1]->
+                            example: isinstance("graph_root") and name=="Batman" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -827,7 +1040,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="Batman" -[0:1]->
+                            example: isinstance("graph_root") and name=="Batman" -[0:1]->
             responses:
                 "200":
                     description: "The result of this query in the defined format"
@@ -888,7 +1101,7 @@ paths:
                     text/plain:
                         schema:
                             type: string
-                            example: kind(graph_root) and name=="Batman" -[0:1]->
+                            example: isinstance("graph_root") and name=="Batman" -[0:1]->
             responses:
                 "200":
                     description: "The execution plan of the database"
@@ -1314,17 +1527,32 @@ components:
                 id:
                     type: string
                     description: "The identifier of this node."
-                data:
+                type:
+                    type: string
+                reported:
                     $ref: "#/components/schemas/Node"
+                desired:
+                    type: object
+                    additionalProperties: true
+                metadata:
+                    type: object
+                    additionalProperties: true
             example:
               {
                   "type": "node",
                   "id": "id-in-graph",
-                  "data": {
+                  "reported": {
                       "kind": "test.person",
                       "name": "Batman",
                       "city": "Gotham"
+                  },
+                  "desired": {
+                      "clean": true
+                  },
+                  "metadata": {
+                      "version": 1
                   }
+
               }
         DesiredNode:
             type: object

--- a/keepercore/core/web/api.py
+++ b/keepercore/core/web/api.py
@@ -59,7 +59,6 @@ class Api:
         static_path = os.path.abspath(os.path.dirname(__file__) + "/../static")
         r = "reported"
         d = "desired"
-        rd = [r, d]
         SwaggerFile(
             self.app,
             spec_file=f"{static_path}/api-doc.yaml",
@@ -73,34 +72,41 @@ class Api:
                 web.patch("/model", self.update_model),
                 # CRUD Graph operations
                 web.get("/graph", self.list_graphs),
-                web.get("/graph/{graph_id}", partial(self.get_node, r)),
+                web.get("/graph/{graph_id}", self.get_node),
                 web.post("/graph/{graph_id}", self.create_graph),
                 web.delete("/graph/{graph_id}", self.wipe),
+                # No section of the graph
+                web.post("/graph/{graph_id}/query", partial(self.query, None)),
+                web.post("/graph/{graph_id}/query/raw", partial(self.raw, None)),
+                web.post("/graph/{graph_id}/query/explain", partial(self.explain, None)),
+                web.post("/graph/{graph_id}/query/list", partial(self.query_list, None)),
+                web.post("/graph/{graph_id}/query/graph", partial(self.query_graph_stream, None)),
+                web.post("/graph/{graph_id}/query/aggregate", partial(self.query_aggregation, None)),
                 # Reported section of the graph
                 web.get("/graph/{graph_id}/reported/search", self.search_graph),
                 web.post("/graph/{graph_id}/reported/merge", self.merge_graph),
                 web.post("/graph/{graph_id}/reported/batch/merge", self.update_merge_graph_batch),
                 web.post("/graph/{graph_id}/reported/node/{node_id}/under/{parent_node_id}", self.create_node),
-                web.get("/graph/{graph_id}/reported/node/{node_id}", partial(self.get_node, r)),
-                web.patch("/graph/{graph_id}/reported/node/{node_id}", partial(self.update_node, r, r)),
+                web.get("/graph/{graph_id}/reported/node/{node_id}", self.get_node),
+                web.patch("/graph/{graph_id}/reported/node/{node_id}", partial(self.update_node, r)),
                 web.delete("/graph/{graph_id}/reported/node/{node_id}", self.delete_node),
                 web.get("/graph/{graph_id}/reported/batch", self.list_batches),
                 web.post("/graph/{graph_id}/reported/batch/{batch_id}", self.commit_batch),
                 web.delete("/graph/{graph_id}/reported/batch/{batch_id}", self.abort_batch),
-                web.post("/graph/{graph_id}/reported/query", partial(self.query, r, r)),
+                web.post("/graph/{graph_id}/reported/query", partial(self.query, r)),
                 web.post("/graph/{graph_id}/reported/query/raw", partial(self.raw, r)),
                 web.post("/graph/{graph_id}/reported/query/explain", partial(self.explain, r)),
-                web.post("/graph/{graph_id}/reported/query/list", partial(self.query_list, r, r)),
-                web.post("/graph/{graph_id}/reported/query/graph", partial(self.query_graph_stream, r, r)),
+                web.post("/graph/{graph_id}/reported/query/list", partial(self.query_list, r)),
+                web.post("/graph/{graph_id}/reported/query/graph", partial(self.query_graph_stream, r)),
                 web.post("/graph/{graph_id}/reported/query/aggregate", partial(self.query_aggregation, r)),
                 # Desired section of the graph
-                web.get("/graph/{graph_id}/desired/node/{node_id}", partial(self.get_node, rd)),
-                web.patch("/graph/{graph_id}/desired/node/{node_id}", partial(self.update_node, d, rd)),
-                web.post("/graph/{graph_id}/desired/query", partial(self.query, d, rd)),
-                web.post("/graph/{graph_id}/desired/query/raw", partial(self.raw, d, rd)),
-                web.post("/graph/{graph_id}/desired/query/explain", partial(self.explain, d, rd)),
-                web.post("/graph/{graph_id}/desired/query/list", partial(self.query_list, d, rd)),
-                web.post("/graph/{graph_id}/desired/query/graph", partial(self.query_graph_stream, d, rd)),
+                web.get("/graph/{graph_id}/desired/node/{node_id}", self.get_node),
+                web.patch("/graph/{graph_id}/desired/node/{node_id}", partial(self.update_node, d)),
+                web.post("/graph/{graph_id}/desired/query", partial(self.query, d)),
+                web.post("/graph/{graph_id}/desired/query/raw", partial(self.raw, d)),
+                web.post("/graph/{graph_id}/desired/query/explain", partial(self.explain, d)),
+                web.post("/graph/{graph_id}/desired/query/list", partial(self.query_list, d)),
+                web.post("/graph/{graph_id}/desired/query/graph", partial(self.query_graph_stream, d)),
                 web.post("/graph/{graph_id}/desired/query/aggregate", partial(self.query_aggregation, d)),
                 # Subscriptions
                 web.get("/subscribers", self.list_all_subscriptions),
@@ -250,11 +256,11 @@ class Api:
         model = await self.model_handler.update_model(kinds)
         return web.json_response(to_js(model))
 
-    async def get_node(self, section: str, request: Request) -> StreamResponse:
+    async def get_node(self, request: Request) -> StreamResponse:
         graph_id = request.match_info.get("graph_id", "ns")
         node_id = request.match_info.get("node_id", "root")
         graph = self.db.get_graph_db(graph_id)
-        node = await graph.get_node(node_id, section)
+        node = await graph.get_node(node_id)
         if node is None:
             return web.HTTPNotFound(text=f"No such node with id {node_id} in graph {graph_id}")
         else:
@@ -270,13 +276,13 @@ class Api:
         node = await graph.create_node(md, node_id, item, parent_node_id)
         return web.json_response(node)
 
-    async def update_node(self, section: str, result_section: Section, request: Request) -> StreamResponse:
+    async def update_node(self, section: str, request: Request) -> StreamResponse:
         graph_id = request.match_info.get("graph_id", "ns")
         node_id = request.match_info.get("node_id", "some_existing")
         graph = self.db.get_graph_db(graph_id)
         patch = await request.json()
         md = await self.model_handler.load_model()
-        node = await graph.update_node(md, section, result_section, node_id, patch)
+        node = await graph.update_node(md, section, node_id, patch)
         return web.json_response(node)
 
     async def delete_node(self, request: Request) -> StreamResponse:
@@ -296,7 +302,7 @@ class Api:
         if "_" in graph_id:
             raise AttributeError("Graph name should not have underscores!")
         graph = await self.db.create_graph(graph_id)
-        root = await graph.get_node("root", "reported")
+        root = await graph.get_node("root")
         return web.json_response(root)
 
     async def merge_graph(self, request: Request) -> StreamResponse:
@@ -334,7 +340,7 @@ class Api:
         await graph_db.abort_batch_update(batch_id)
         return web.HTTPOk(body="Batch aborted.")
 
-    async def raw(self, query_section: str, request: Request) -> StreamResponse:
+    async def raw(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         graph_db = self.db.get_graph_db(request.match_info.get("graph_id", "ns"))
         m = await self.model_handler.load_model()
@@ -342,7 +348,7 @@ class Api:
         query, bind_vars = graph_db.to_query(QueryModel(q, m, query_section))
         return web.json_response({"query": query, "bind_vars": bind_vars})
 
-    async def explain(self, query_section: str, request: Request) -> StreamResponse:
+    async def explain(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         graph_db = self.db.get_graph_db(request.match_info.get("graph_id", "ns"))
         q = parse_query(query_string)
@@ -362,34 +368,34 @@ class Api:
         # noinspection PyTypeChecker
         return await self.stream_response_from_gen(request, (to_js(a) async for a in result))
 
-    async def query_list(self, query_section: str, result_section: Section, request: Request) -> StreamResponse:
+    async def query_list(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         graph_db = self.db.get_graph_db(request.match_info.get("graph_id", "ns"))
         q = parse_query(query_string)
         m = await self.model_handler.load_model()
-        result = graph_db.query_list(QueryModel(q, m, query_section, result_section))
+        result = graph_db.query_list(QueryModel(q, m, query_section))
         # noinspection PyTypeChecker
         return await self.stream_response_from_gen(request, (to_js(a) async for a in result))
 
-    async def cytoscape(self, query_section: str, result_section: Section, request: Request) -> StreamResponse:
+    async def cytoscape(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         graph_db = self.db.get_graph_db(request.match_info.get("graph_id", "ns"))
         q = parse_query(query_string)
         m = await self.model_handler.load_model()
-        result = await graph_db.query_graph(QueryModel(q, m, query_section, result_section))
+        result = await graph_db.query_graph(QueryModel(q, m, query_section))
         node_link_data = cytoscape_data(result)
         return web.json_response(node_link_data)
 
-    async def query_graph_stream(self, query_section: str, result_section: Section, request: Request) -> StreamResponse:
+    async def query_graph_stream(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         q = parse_query(query_string)
         m = await self.model_handler.load_model()
         graph_db = self.db.get_graph_db(request.match_info.get("graph_id", "ns"))
-        gen = graph_db.query_graph_gen(QueryModel(q, m, query_section, result_section))
+        gen = graph_db.query_graph_gen(QueryModel(q, m, query_section))
         # noinspection PyTypeChecker
         return await self.stream_response_from_gen(request, (item async for _, item in gen))
 
-    async def query_aggregation(self, query_section: str, request: Request) -> StreamResponse:
+    async def query_aggregation(self, query_section: Optional[str], request: Request) -> StreamResponse:
         query_string = await request.text()
         q = parse_query(query_string)
         m = await self.model_handler.load_model()
@@ -398,13 +404,13 @@ class Api:
         # noinspection PyTypeChecker
         return await self.stream_response_from_gen(request, gen)
 
-    async def query(self, query_section: str, result_section: Section, request: Request) -> StreamResponse:
+    async def query(self, query_section: Optional[str], request: Request) -> StreamResponse:
         if request.headers.get("format") == "cytoscape":
-            return await self.cytoscape(query_section, result_section, request)
+            return await self.cytoscape(query_section, request)
         if request.headers.get("format") == "graph":
-            return await self.query_graph_stream(query_section, result_section, request)
+            return await self.query_graph_stream(query_section, request)
         elif request.headers.get("format") == "list":
-            return await self.query_list(query_section, result_section, request)
+            return await self.query_list(query_section, request)
         else:
             return web.HTTPPreconditionFailed(text="Define format header. `format: [graph|list|cytoscape]`")
 

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -331,13 +331,13 @@ async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model)
 
 @pytest.mark.asyncio
 async def test_get_node(filled_graph_db: ArangoGraphDB) -> None:
-    root = to_foo(await filled_graph_db.get_node("sub_root", "reported"))
+    root = to_foo(await filled_graph_db.get_node("sub_root"))
     assert root is not None
     assert isinstance(root, Foo)
-    node_7 = to_foo(await filled_graph_db.get_node("7", "reported"))
+    node_7 = to_foo(await filled_graph_db.get_node("7"))
     assert node_7 is not None
     assert isinstance(node_7, Foo)
-    node_1_2 = to_bla(await filled_graph_db.get_node("1_2", "reported"))
+    node_1_2 = to_bla(await filled_graph_db.get_node("1_2"))
     assert node_1_2 is not None
     assert isinstance(node_1_2, Bla)
 
@@ -347,16 +347,16 @@ async def test_insert_node(graph_db: ArangoGraphDB, foo_model: Model) -> None:
     await graph_db.wipe()
     json = await graph_db.create_node(foo_model, "some_new_id", to_json(Foo("some_new_id", "name")), "root")
     assert to_foo(json).identifier == "some_new_id"
-    assert to_foo(await graph_db.get_node("some_new_id", "reported")).identifier == "some_new_id"
+    assert to_foo(await graph_db.get_node("some_new_id")).identifier == "some_new_id"
 
 
 @pytest.mark.asyncio
 async def test_update_node(graph_db: ArangoGraphDB, foo_model: Model) -> None:
     await graph_db.wipe()
     await graph_db.create_node(foo_model, "some_other", to_json(Foo("some_other", "foo")), "root")
-    json = await graph_db.update_node(foo_model, "reported", "reported", "some_other", {"name": "bla"})
+    json = await graph_db.update_node(foo_model, "reported", "some_other", {"name": "bla"})
     assert to_foo(json).name == "bla"
-    assert to_foo(await graph_db.get_node("some_other", "reported")).name == "bla"
+    assert to_foo(await graph_db.get_node("some_other")).name == "bla"
 
 
 @pytest.mark.asyncio
@@ -366,7 +366,7 @@ async def test_delete_node(graph_db: ArangoGraphDB, foo_model: Model) -> None:
     await graph_db.create_node(foo_model, "some_other_child", to_json(Foo("some_other_child", "foo")), "sub_root")
     await graph_db.create_node(foo_model, "born_to_die", to_json(Foo("born_to_die", "foo")), "sub_root")
     await graph_db.delete_node("born_to_die")
-    assert await graph_db.get_node("born_to_die", "reported") is None
+    assert await graph_db.get_node("born_to_die") is None
     with pytest.raises(AttributeError) as not_allowed:
         await graph_db.delete_node("sub_root")
     assert str(not_allowed.value) == "Can not delete node, since it has 1 child(ren)!"
@@ -376,7 +376,7 @@ async def test_delete_node(graph_db: ArangoGraphDB, foo_model: Model) -> None:
 async def test_events(event_graph_db: EventGraphDB, foo_model: Model, all_events: List[Message]) -> None:
     graph = create_graph("yes or no", width=0)
     await event_graph_db.create_node(foo_model, "some_other", to_json(Foo("some_other", "foo")), "root")
-    await event_graph_db.update_node(foo_model, "reported", "reported", "some_other", {"name": "bla"})
+    await event_graph_db.update_node(foo_model, "reported", "some_other", {"name": "bla"})
     await event_graph_db.delete_node("some_other")
     await event_graph_db.merge_graph(graph)
     await event_graph_db.merge_graph(graph, "batch1")


### PR DESCRIPTION
Example:
```
reported.name=="foo" and desired.cleaned==true and metadata.version>2
```

Following new endpoints are available:
- `POST /graph/{graph_id}/query`
- `POST /graph/{graph_id}/query/raw`
- `POST /graph/{graph_id}/query/explain`
- `POST /graph/{graph_id}/query/list`
- `POST /graph/{graph_id}/query/graph`
- `POST /graph/{graph_id}/query/aggregate`