### PR TITLE
[keepercore] merge nodes as part of the query

### DIFF
--- a/keepercore/core/cli/command.py
+++ b/keepercore/core/cli/command.py
@@ -26,6 +26,8 @@ from core.cli.cli import (
     Ancestor,
     Descendant,
     QueryPart,
+    AggregatePart,
+    MergeAncestorsPart,
 )
 from core.db.model import QueryModel
 from core.error import CLIParseError
@@ -164,7 +166,7 @@ class QuerySource(CLISource):
         db = self.dependencies.db_access.get_graph_db(graph_name)
         query_model = QueryModel(query, model, None)
         db.to_query(query_model)  # only here to validate the query itself (can throw)
-        return db.query_list(query_model)
+        return db.query_aggregation(query_model) if query.aggregate else db.query_list(query_model)
 
 
 class EnvSource(CLISource):
@@ -533,7 +535,17 @@ def all_commands(d: CLIDependencies) -> List[CLICommand]:
 
 
 def all_query_parts(d: CLIDependencies) -> List[QueryPart]:
-    return [ReportedPart(d), DesiredPart(d), MetadataPart(d), Predecessor(d), Successor(d), Ancestor(d), Descendant(d)]
+    return [
+        ReportedPart(d),
+        DesiredPart(d),
+        MetadataPart(d),
+        Predecessor(d),
+        Successor(d),
+        Ancestor(d),
+        Descendant(d),
+        AggregatePart(d),
+        MergeAncestorsPart(d),
+    ]
 
 
 def all_parts(d: CLIDependencies) -> List[CLIPart]:

--- a/keepercore/core/db/graphdb.py
+++ b/keepercore/core/db/graphdb.py
@@ -635,7 +635,7 @@ class ArangoGraphDB(GraphDB):
         query = query_model.query
         model = query_model.model
         section_dot = f"{query_model.query_section}." if query_model.query_section else ""
-        mw = query.preamble.get("merge_with")
+        mw = query.preamble.get("merge_with_ancestors")
         merge_with: list[str] = re.split("\\s*,\\s*", str(mw)) if mw else []
         bind_vars: Json = {}
 

--- a/keepercore/core/db/graphdb.py
+++ b/keepercore/core/db/graphdb.py
@@ -5,7 +5,6 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import partial
-from itertools import chain
 from typing import Optional, Tuple, List, Callable, AsyncGenerator, Any, Iterable, Union
 
 from arango.collection import VertexCollection, StandardCollection, EdgeCollection
@@ -643,8 +642,9 @@ class ArangoGraphDB(GraphDB):
 
             variables = ", ".join(f"{v.get_as_name()}={cursor}.{section_dot}{v.name}" for v in a.group_by)
             funcs = ", ".join(f"{v.get_as_name()}={v.function}({func_term(v.name)})" for v in a.group_func)
-            agg = ", ".join(chain((v.get_as_name() for v in a.group_by), (f.get_as_name() for f in a.group_func)))
-            return f"collect {variables} aggregate {funcs}", f"{{{agg}}}"
+            agg_vars = ", ".join(v.get_as_name() for v in a.group_by)
+            agg_funcs = ", ".join(f.get_as_name() for f in a.group_func)
+            return f"collect {variables} aggregate {funcs}", f'{{"group":{{{agg_vars}}}, {agg_funcs}}}'
 
         def predicate(cursor: str, p: Predicate) -> str:
             extra = ""

--- a/keepercore/core/db/graphdb.py
+++ b/keepercore/core/db/graphdb.py
@@ -642,10 +642,12 @@ class ArangoGraphDB(GraphDB):
                 name = f"{cursor}.{section_dot}{fn.name}" if isinstance(fn.name, str) else str(fn.name)
                 return f"{name} {fn.combined_ops()}" if fn.ops else name
 
-            variables = ", ".join(f"{v.get_as_name()}={cursor}.{section_dot}{v.name}" for v in a.group_by)
-            funcs = ", ".join(f"{v.get_as_name()}={v.function}({func_term(v)})" for v in a.group_func)
-            agg_vars = ", ".join(v.get_as_name() for v in a.group_by)
-            agg_funcs = ", ".join(f.get_as_name() for f in a.group_func)
+            vs = {v.name: f"var_{num}" for num, v in enumerate(a.group_by)}
+            fs = {v.name: f"fn_{num}" for num, v in enumerate(a.group_func)}
+            variables = ", ".join(f"{vs[v.name]}={cursor}.{section_dot}{v.name}" for v in a.group_by)
+            funcs = ", ".join(f"{fs[v.name]}={v.function}({func_term(v)})" for v in a.group_func)
+            agg_vars = ", ".join(f'"{v.get_as_name()}": {vs[v.name]}' for v in a.group_by)
+            agg_funcs = ", ".join(f'"{f.get_as_name()}": {fs[f.name]}' for f in a.group_func)
             return f"collect {variables} aggregate {funcs}", f'{{"group":{{{agg_vars}}}, {agg_funcs}}}'
 
         def predicate(cursor: str, p: Predicate) -> str:

--- a/keepercore/core/db/graphdb.py
+++ b/keepercore/core/db/graphdb.py
@@ -634,7 +634,7 @@ class ArangoGraphDB(GraphDB):
         model = query_model.model
         section_dot = f"{query_model.query_section}." if query_model.query_section else ""
         mw = query.preamble.get("merge_with")
-        merge_with = re.split("\\s*,\\s*", mw) if mw else []
+        merge_with: list[str] = re.split("\\s*,\\s*", str(mw)) if mw else []
         bind_vars: Json = {}
 
         def aggregate(cursor: str, a: Aggregate) -> Tuple[str, str]:
@@ -714,13 +714,13 @@ class ArangoGraphDB(GraphDB):
             return p, idx, out, query_part
 
         def merge_parents(cursor: str, part_str: str, parents: list[str]) -> tuple[str, str]:
-            # bind_vars["merge_stop_at"] = parents[0]
+            bind_vars["merge_stop_at"] = parents[0]
             bind_vars["merge_parent_parent_nodes"] = parents
             parts = [
                 f"FOR node in {cursor} "
                 + "LET parent_nodes = ("
                 + f"FOR p IN 1..1000 INBOUND node {self.edge_collection(EdgeType.default)} "
-                # + "PRUNE @merge_stop_at in p.kinds "
+                + "PRUNE @merge_stop_at in p.kinds "
                 + "OPTIONS {order: 'bfs', uniqueVertices: 'global'} "
                 + "FILTER p.kinds any in @merge_parent_parent_nodes RETURN p)"
             ]

--- a/keepercore/core/model/model.py
+++ b/keepercore/core/model/model.py
@@ -720,9 +720,9 @@ class Model:
                 # Filter out duplicates that have the same kind or any side is any
                 non_unique = list(filter(simple_kind_incompatible, intersect))
                 if non_unique:
-                    message = ", ".join(repr(a) for a in non_unique)
+                    message = ", ".join(f"{a} ({all_paths[a].fqn} -> {paths[a].fqn})" for a in non_unique)
                     raise AttributeError(
-                        f"Update not possible. Following properties would be non unique having "
+                        f"Update not possible. {kind.fqn}: following properties would be non unique having "
                         f"the same path but different type: {message}"
                     )
                 return paths | all_paths

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -345,7 +345,7 @@ class Query:
         if parts is None or len(parts) == 0:
             raise AttributeError(f"Expected non empty parts but got {parts}")
         self.parts = parts
-        self.preamble: dict[str, str] = preamble if preamble else dict()
+        self.preamble: dict[str, SimpleValue] = preamble if preamble else dict()
         self.aggregate = aggregate
 
     @staticmethod

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -308,9 +308,9 @@ class AggregateVariable:
 
 
 class AggregateFunction:
-    def __init__(self, function: str, name: str, as_name: Optional[str] = None):
+    def __init__(self, function: str, name_or_value: Union[str, int], as_name: Optional[str] = None):
         self.function = function
-        self.name = name
+        self.name = name_or_value
         self.as_name = as_name
 
     def __str__(self) -> str:
@@ -318,7 +318,7 @@ class AggregateFunction:
         return f"{self.function}({self.name}){with_as}"
 
     def get_as_name(self) -> str:
-        return self.as_name if self.as_name else self.name
+        return self.as_name if self.as_name else f"{self.function}_of_{self.name}"
 
 
 class Aggregate:

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -308,14 +308,25 @@ class AggregateVariable:
 
 
 class AggregateFunction:
-    def __init__(self, function: str, name_or_value: Union[str, int], as_name: Optional[str] = None):
+    def __init__(
+        self,
+        function: str,
+        name_or_value: Union[str, int],
+        ops: Optional[list[tuple[str, Union[int, float]]]] = None,
+        as_name: Optional[str] = None,
+    ):
         self.function = function
         self.name = name_or_value
+        self.ops: list[tuple[str, Union[int, float]]] = ops if ops else []
         self.as_name = as_name
 
     def __str__(self) -> str:
         with_as = f" as {self.as_name}" if self.as_name else ""
-        return f"{self.function}({self.name}){with_as}"
+        with_ops = " " + self.combined_ops() if self.ops else ""
+        return f"{self.function}({self.name}{with_ops}){with_as}"
+
+    def combined_ops(self) -> str:
+        return " ".join(f"{op} {value}" for op, value in self.ops)
 
     def get_as_name(self) -> str:
         return self.as_name if self.as_name else f"{self.function}_of_{self.name}"

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -369,7 +369,7 @@ class Query:
     def __str__(self) -> str:
         aggregate = str(self.aggregate) if self.aggregate else ""
         to_str = Predicate.value_str_rep
-        preamble = "{" + ", ".join(f"{k}={to_str(v)}" for k, v in self.preamble.items()) + "}" if self.preamble else ""
+        preamble = "(" + ", ".join(f"{k}={to_str(v)}" for k, v in self.preamble.items()) + ")" if self.preamble else ""
         colon = ":" if self.preamble or self.aggregate else ""
         parts = " ".join(str(a) for a in reversed(self.parts))
         return f"{aggregate}{preamble}{colon}{parts}"

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -332,11 +332,14 @@ class Aggregate:
         return f"aggregate({group_by}: {funcs})"
 
 
+SimpleValue = Union[str, int, float, bool]
+
+
 class Query:
     def __init__(
         self,
         parts: List[Part],
-        preamble: Optional[dict[str, str]] = None,
+        preamble: Optional[dict[str, SimpleValue]] = None,
         aggregate: Optional[Aggregate] = None,
     ):
         if parts is None or len(parts) == 0:
@@ -346,14 +349,17 @@ class Query:
         self.aggregate = aggregate
 
     @staticmethod
-    def by(term: Union[str, Term], *terms: Union[str, Term], preamble: Optional[dict[str, str]] = None) -> Query:
+    def by(
+        term: Union[str, Term], *terms: Union[str, Term], preamble: Optional[dict[str, SimpleValue]] = None
+    ) -> Query:
         res = Query.mk_term(term, *terms)
         return Query([Part(res)], preamble)
 
     def __str__(self) -> str:
         aggregate = str(self.aggregate) if self.aggregate else ""
-        preamble = "{" + ", ".join(f'{k}="{v}"' for k, v in self.preamble.items()) + "}" if self.preamble else ""
-        colon = ":" if len(self.preamble) > 0 or self.aggregate else ""
+        to_str = Predicate.value_str_rep
+        preamble = "{" + ", ".join(f"{k}={to_str(v)}" for k, v in self.preamble.items()) + "}" if self.preamble else ""
+        colon = ":" if self.preamble or self.aggregate else ""
         parts = " ".join(str(a) for a in reversed(self.parts))
         return f"{aggregate}{preamble}{colon}{parts}"
 

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -206,13 +206,13 @@ def aggregate_group_variable_parser() -> Parser:
 def aggregate_group_function_parser() -> Parser:
     func = yield aggregate_func_p
     yield lparen_p
-    name = yield variable_p
+    name_or_int = yield variable_p | integer_p
     yield rparen_p
     with_as = yield as_p.optional()
     as_name = None
     if with_as:
         as_name = yield literal_p
-    return AggregateFunction(func, name, as_name)
+    return AggregateFunction(func, name_or_int, as_name)
 
 
 @make_parser

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -202,17 +202,28 @@ def aggregate_group_variable_parser() -> Parser:
     return AggregateVariable(name, as_name)
 
 
+math_op_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["+", "-", "*", "/"]])
+
+
+@make_parser
+def op_with_val_parser() -> Parser:
+    op = yield math_op_p
+    value = yield float_p | integer_p
+    return op, value
+
+
 @make_parser
 def aggregate_group_function_parser() -> Parser:
     func = yield aggregate_func_p
     yield lparen_p
-    name_or_int = yield variable_p | integer_p
+    term_or_int = yield variable_p | integer_p
+    ops_list = yield op_with_val_parser.many()
     yield rparen_p
     with_as = yield as_p.optional()
     as_name = None
     if with_as:
         as_name = yield literal_p
-    return AggregateFunction(func, name_or_int, as_name)
+    return AggregateFunction(func, term_or_int, ops_list, as_name)
 
 
 @make_parser

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -227,12 +227,18 @@ def aggregate_group_function_parser() -> Parser:
 
 
 @make_parser
-def aggregate_parser() -> Parser:
-    yield aggregate_p
-    yield lparen_p
+def aggregate_parameter_parser() -> Parser:
     group_vars = yield aggregate_group_variable_parser.sep_by(comma_p, min=1)
     yield colon_p
     group_function_vars = yield aggregate_group_function_parser.sep_by(comma_p, min=1)
+    return group_vars, group_function_vars
+
+
+@make_parser
+def aggregate_parser() -> Parser:
+    yield aggregate_p
+    yield lparen_p
+    group_vars, group_function_vars = yield aggregate_parameter_parser
     yield rparen_p
     return Aggregate(group_vars, group_function_vars)
 

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -50,7 +50,7 @@ operation_p = reduce(
 function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change"]])
 
 
-preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type"]])
+preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type", "merge_with"]])
 
 lparen_p = lexeme(lparen_dp)
 rparen_p = lexeme(rparen_dp)
@@ -174,7 +174,7 @@ def part_parser() -> Parser:
 def key_value_parser() -> Parser:
     key = yield preamble_prop_p
     yield equals_p
-    value = yield quoted_string_p | literal_p
+    value = yield quoted_string_p | true_p | false_p | float_p | integer_p | literal_p
     return key, value
 
 
@@ -254,7 +254,7 @@ def query_parser() -> Parser:
     for part in parts:
         if part.navigation and not part.navigation.edge_type:
             part.navigation.edge_type = edge_type
-    return Query(parts[::-1], maybe_aggregate)
+    return Query(parts[::-1], preamble, maybe_aggregate)
 
 
 def parse_query(query: str) -> Query:

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -202,7 +202,7 @@ def aggregate_group_variable_parser() -> Parser:
     return AggregateVariable(name, as_name)
 
 
-math_op_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["+", "-", "*", "/"]])
+math_op_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["+", "-", "*", "/", "%"]])
 
 
 @make_parser

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -180,9 +180,9 @@ def key_value_parser() -> Parser:
 
 @make_parser
 def preamble_tags_parser() -> Parser:
-    yield l_curly_p
+    yield lparen_p
     key_values = yield key_value_parser.sep_by(comma_p)
-    yield r_curly_p
+    yield rparen_p
     return dict(key_values)
 
 

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -50,7 +50,7 @@ operation_p = reduce(
 function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change"]])
 
 
-preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type", "merge_with"]])
+preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type", "merge_with_ancestors"]])
 
 lparen_p = lexeme(lparen_dp)
 rparen_p = lexeme(rparen_dp)

--- a/keepercore/core/web/api.py
+++ b/keepercore/core/web/api.py
@@ -431,7 +431,7 @@ class Api:
         parsed = await self.cli.evaluate_cli_command(command, **env)
         # simply return the structure: outer array lines, inner array commands
         # if the structure is returned, it means the command could be evaluated.
-        return web.json_response([[p.name for p in line.parts] for line in parsed])
+        return web.json_response([{part.name: arg for part, arg in line.parts_with_args} for line in parsed])
 
     async def execute(self, request: Request) -> StreamResponse:
         # all query parameter become the env of this command

--- a/keepercore/tests/core/cli/cli_test.py
+++ b/keepercore/tests/core/cli/cli_test.py
@@ -156,3 +156,9 @@ async def test_create_query_parts(cli: CLI) -> None:
     assert commands[0].parts_with_args[0][1] == "reported.some_int == 0 -delete[1:]->"
     commands = await cli.evaluate_cli_command("reported some_int==0 | ancestors delete")
     assert commands[0].parts_with_args[0][1] == "reported.some_int == 0 <-delete[1:]-"
+    # defining merge_ancestors
+    commands = await cli.evaluate_cli_command("reported some_int==0 | merge_ancestors foo")
+    assert commands[0].parts_with_args[0][1] == '(merge_with_ancestors="foo"):reported.some_int == 0'
+    # defining merge_ancestors
+    commands = await cli.evaluate_cli_command("reported some_int==0 | aggregate foo, bla as bla: sum(bar)")
+    assert commands[0].parts_with_args[0][1] == "aggregate(foo, bla as bla: sum(bar)):reported.some_int == 0"

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -333,7 +333,7 @@ async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model)
 
 @pytest.mark.asyncio
 async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
-    agg_query = parse_query('{merge_with="foo,bar"}: isinstance("bla")')
+    agg_query = parse_query('(merge_with="foo,bar"): isinstance("bla")')
     async for bla in filled_graph_db.query_list(QueryModel(agg_query, foo_model, "reported")):
         js = AccessJson(bla)
         assert "bar" in js.reported  # key exists

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -333,15 +333,15 @@ async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model)
 
 @pytest.mark.asyncio
 async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
-    agg_query = parse_query('(merge_with="foo,bar"): isinstance("bla")')
+    agg_query = parse_query('(merge_with="foo as foobar,bar"): isinstance("bla")')
     async for bla in filled_graph_db.query_list(QueryModel(agg_query, foo_model, "reported")):
         js = AccessJson(bla)
         assert "bar" in js.reported  # key exists
         assert js.reported.bar is None  # bla is not a parent of this node
-        assert "foo" in js.reported  # key exists
-        assert js.reported.foo is not None  # foo is merged into reported
-        # make sure the correct parent is merged (foo(1) -> bla(1_xxx))
-        assert js.reported.identifier.startswith(js.reported.foo.identifier)
+        assert "foobar" in js.reported  # key exists
+        assert js.reported.foobar is not None  # foobar is merged into reported
+        # make sure the correct parent is merged (foobar(1) -> bla(1_xxx))
+        assert js.reported.identifier.startswith(js.reported.foobar.identifier)
 
 
 @pytest.mark.asyncio

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -333,7 +333,7 @@ async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model)
 
 @pytest.mark.asyncio
 async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
-    agg_query = parse_query('(merge_with="foo as foobar,bar"): isinstance("bla")')
+    agg_query = parse_query('(merge_with_ancestors="foo as foobar,bar"): isinstance("bla")')
     async for bla in filled_graph_db.query_list(QueryModel(agg_query, foo_model, "reported")):
         js = AccessJson(bla)
         assert "bar" in js.reported  # key exists

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -328,7 +328,7 @@ async def test_query_graph(filled_graph_db: ArangoGraphDB, foo_model: Model) -> 
 async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
     agg_query = parse_query('aggregate(kind: count(identifier) as instances): isinstance("foo")')
     gen = filled_graph_db.query_aggregation(QueryModel(agg_query, foo_model, "reported"))
-    assert [x async for x in gen] == [{"kind": "foo", "instances": 13}]
+    assert [x async for x in gen] == [{"group": {"kind": "foo"}, "instances": 13}]
 
 
 @pytest.mark.asyncio

--- a/keepercore/tests/core/model/model_test.py
+++ b/keepercore/tests/core/model/model_test.py
@@ -267,7 +267,7 @@ def test_update(person_model: Model) -> None:
         )
     assert (
         str(not_allowed.value)
-        == "Update not possible. Following properties would be non unique having the same path but different type: city"
+        == "Update not possible. Address: following properties would be non unique having the same path but different type: city (string -> int32)"
     )
 
     updated = person_model.update_kinds([StringKind("Foo")])
@@ -279,7 +279,7 @@ def test_update(person_model: Model) -> None:
         updated.update_kinds([Complex("Bla", [], [Property("id", "int32")])])
     assert (
         str(duplicate.value)
-        == "Update not possible. Following properties would be non unique having the same path but different type: id"
+        == "Update not possible. Bla: following properties would be non unique having the same path but different type: id (string -> int32)"
     )
 
 

--- a/keepercore/tests/core/query/query_parser_test.py
+++ b/keepercore/tests/core/query/query_parser_test.py
@@ -114,6 +114,10 @@ def test_query_with_preamble() -> None:
 
 def test_preamble_tags() -> None:
     assert preamble_tags_parser.parse("{edge_type=foo}") == {"edge_type": "foo"}
+    assert preamble_tags_parser.parse("{edge_type=23}") == {"edge_type": 23}
+    assert preamble_tags_parser.parse("{edge_type=23.123}") == {"edge_type": 23.123}
+    assert preamble_tags_parser.parse("{edge_type=true}") == {"edge_type": True}
+    assert preamble_tags_parser.parse("{edge_type=false}") == {"edge_type": False}
     assert preamble_tags_parser.parse('{edge_type="!@#*(&$({{:::"}') == {"edge_type": "!@#*(&$({{:::"}
     assert preamble_parser.parse("") == (None, {})
 

--- a/keepercore/tests/core/query/query_parser_test.py
+++ b/keepercore/tests/core/query/query_parser_test.py
@@ -91,7 +91,7 @@ def test_part() -> None:
 
 def test_query() -> None:
     query = (
-        Query.by("ec2", P("cpu") > 4, (P("mem") < 23) | (P("mem") < 59))
+        Query.by("ec2", P("cpu") > 4, (P("mem") < 23) | (P("mem") < 59), preamble={"edge_type": EdgeType.default})
         .traverse_out()
         .filter(P("some.int.value") < 1, P("some.other") == 23)
         .traverse_out()

--- a/keepercore/tests/core/query/query_parser_test.py
+++ b/keepercore/tests/core/query/query_parser_test.py
@@ -107,20 +107,20 @@ def test_query_with_preamble() -> None:
     query_parser.parse('id("root")')  # no preamble
     query_parser.parse('match: id("root")')  # match preamble
     query_parser.parse('match(): id("root")')  # match preamble
-    query = query_parser.parse('{edge_type=delete}: id("root") -[0:1]->')
+    query = query_parser.parse('(edge_type=delete): id("root") -[0:1]->')
     assert query.parts[0].navigation.edge_type == "delete"
-    query = query_parser.parse('aggregate(region: sum(cpu)){edge_type=delete}: id("root") -[0:1]->')
+    query = query_parser.parse('aggregate(region: sum(cpu))(edge_type=delete): id("root") -[0:1]->')
     assert query.aggregate.group_by[0].name == "region"
     assert query.aggregate.group_func[0].name == "cpu"
 
 
 def test_preamble_tags() -> None:
-    assert preamble_tags_parser.parse("{edge_type=foo}") == {"edge_type": "foo"}
-    assert preamble_tags_parser.parse("{edge_type=23}") == {"edge_type": 23}
-    assert preamble_tags_parser.parse("{edge_type=23.123}") == {"edge_type": 23.123}
-    assert preamble_tags_parser.parse("{edge_type=true}") == {"edge_type": True}
-    assert preamble_tags_parser.parse("{edge_type=false}") == {"edge_type": False}
-    assert preamble_tags_parser.parse('{edge_type="!@#*(&$({{:::"}') == {"edge_type": "!@#*(&$({{:::"}
+    assert preamble_tags_parser.parse("(edge_type=foo)") == {"edge_type": "foo"}
+    assert preamble_tags_parser.parse("(edge_type=23)") == {"edge_type": 23}
+    assert preamble_tags_parser.parse("(edge_type=23.123)") == {"edge_type": 23.123}
+    assert preamble_tags_parser.parse("(edge_type=true)") == {"edge_type": True}
+    assert preamble_tags_parser.parse("(edge_type=false)") == {"edge_type": False}
+    assert preamble_tags_parser.parse('(edge_type="!@#*(&$({{:::")') == {"edge_type": "!@#*(&$({{:::"}
     assert preamble_parser.parse("") == (None, {})
 
 

--- a/keepercore/tests/core/query/query_parser_test.py
+++ b/keepercore/tests/core/query/query_parser_test.py
@@ -1,5 +1,7 @@
 from typing import Callable, Optional, Any
 
+import pytest
+
 from core.query.model import Navigation, Part, Query, P, AggregateVariable, Aggregate, AggregateFunction
 from core.model.graph_access import EdgeType
 from parsy import Parser
@@ -140,6 +142,10 @@ def test_aggregate_group_function() -> None:
     assert foo.function == "sum"
     assert bla.name == "bla"
     assert bla.as_name == "bar"
+    boo = aggregate_group_function_parser.parse("sum(boo * 1024.12 + 1) as bar")
+    assert boo.ops == [("*", 1024.12), ("+", 1)]
+    with pytest.raises(Exception):
+        assert aggregate_group_function_parser.parse("sum(test / 3 +)")
 
 
 def test_aggregate() -> None:


### PR DESCRIPTION
Allows definition of `merge_with="parent_kind,..,parent_kind"`
The specified kinds are searched in the graph and merged with every search result.
Example:
```
{merge_with="cloud,account"}: isinstance("instance_quota")
```
will search all nodes of kind `instance_quota`. 
The result will additionally contain following properties in the reported section:
- cloud: the first predecessor of the instance node of type `cloud`
- account: the first predecessor of the instance node of type `account`

This can be used to aggregate values like this:
```
aggregate(cloud.name as cloud, region.name as region : sum(quota) as quota) {merge_with="cloud,region"}: isinstance("base_instance_quota")
```
