### PR TITLE
[keepercore] Resolve common graph references during import

### DIFF
--- a/keepercore/core/__main__.py
+++ b/keepercore/core/__main__.py
@@ -11,6 +11,7 @@ from core.cli.command import all_parts, aliases
 from core.db.arangodb_extensions import ArangoHTTPClient
 from core.db.db_access import DbAccess
 from core.event_bus import EventBus
+from core.model.adjust_node import DirectAdjuster
 from core.model.model_handler import ModelHandlerDB
 from core.worker_task_queue import WorkerTaskQueue
 from core.web.api import Api
@@ -53,7 +54,8 @@ def main() -> None:
     http_client = ArangoHTTPClient(args.arango_request_timeout, not args.arango_no_ssl_verify)
     client = ArangoClient(hosts=args.arango_server, http_client=http_client)
     database = client.db(args.arango_database, username=args.arango_username, password=args.arango_password)
-    db = DbAccess(database, event_bus)
+    adjuster = DirectAdjuster()
+    db = DbAccess(database, event_bus, adjuster)
     model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
     cli_deps = CLIDependencies()
     cli = CLI(cli_deps, all_parts(cli_deps), dict(os.environ), aliases())

--- a/keepercore/core/model/adjust_node.py
+++ b/keepercore/core/model/adjust_node.py
@@ -1,0 +1,54 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from core.model.model import DateTimeKind
+from core.types import Json
+from core.util import value_in_path, from_utc
+
+log = logging.getLogger(__name__)
+
+
+class AdjustNode(ABC):
+    @abstractmethod
+    def adjust(self, json: Json) -> Json:
+        pass
+
+
+class NoAdjust(AdjustNode):
+    def adjust(self, json: Json) -> Json:
+        return json
+
+
+class DirectAdjuster(AdjustNode):
+    dt = DateTimeKind("datetime")
+    expiration_values = [
+        ["reported", "tags", "cloudkeeper:expiration"],
+        ["reported", "tags", "cloudkeeper:expires"],
+        ["reported", "tags", "expires"],
+        ["reported", "tags", "expiration"],
+    ]
+
+    def adjust(self, json: Json) -> Json:
+        def expires_tag() -> Optional[str]:
+            for path in self.expiration_values:
+                expiration: Optional[str] = value_in_path(json, path)
+                if expiration:
+                    return expiration
+            return None
+
+        expires_in = expires_tag()
+        if expires_in:
+            try:
+                if DateTimeKind.DurationRe.fullmatch(expires_in):
+                    ctime = from_utc(json["reported"]["ctime"])
+                    expires = DateTimeKind.from_duration(expires_in, ctime)
+                else:
+                    expires = self.dt.coerce(expires_in)
+                if "metadata" not in json:
+                    json["metadata"] = {}
+                json["metadata"]["expires"] = expires
+            except Exception as ex:
+                log.info(f"Could not parse expires {ex}")
+        # json is mutated to save memory
+        return json

--- a/keepercore/core/model/adjust_node.py
+++ b/keepercore/core/model/adjust_node.py
@@ -49,6 +49,6 @@ class DirectAdjuster(AdjustNode):
                     json["metadata"] = {}
                 json["metadata"]["expires"] = expires
             except Exception as ex:
-                log.info(f"Could not parse expires {ex}")
+                log.debug(f"Could not parse expires {ex}")
         # json is mutated to save memory
         return json

--- a/keepercore/core/model/resolve_in_graph.py
+++ b/keepercore/core/model/resolve_in_graph.py
@@ -8,6 +8,7 @@ class NodePath:
     node_id = ["id"]
     kinds = ["kinds"]
     reported_kind = ["reported", "kind"]
+    reported_ctime = ["reported", "ctime"]
     reported_id = ["reported", "id"]
     reported_name = ["reported", "name"]
 

--- a/keepercore/core/model/resolve_in_graph.py
+++ b/keepercore/core/model/resolve_in_graph.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class NodePath:
+    node_id = ["id"]
+    kinds = ["kinds"]
+    reported_kind = ["reported", "kind"]
+    reported_id = ["reported", "id"]
+    reported_name = ["reported", "name"]
+
+
+@dataclass(frozen=True)
+class ResolveProp:
+    # Path to the property that needs to be extracted
+    extract_path: list[str]
+    # section to write the result (e.g. metadata, refs etc)
+    section: str
+    # name of property in section
+    name: str
+
+
+@dataclass(frozen=True)
+class ResolveAncestor:
+    # kind of ancestor. Stop at first occurrence.
+    kind: str
+    # List of all properties to be resolved.
+    resolve: list[ResolveProp]
+
+    def resolves_id(self) -> Optional[ResolveProp]:
+        for prop in self.resolve:
+            if prop.extract_path == NodePath.node_id:
+                return prop
+        return None
+
+
+class GraphResolver:
+    to_resolve = [
+        ResolveAncestor(
+            "cloud",
+            [
+                ResolveProp(NodePath.reported_name, "metadata", "cloud"),
+                ResolveProp(NodePath.node_id, "refs", "cloud_id"),
+            ],
+        ),
+        ResolveAncestor(
+            "account",
+            [
+                ResolveProp(NodePath.reported_name, "metadata", "account"),
+                ResolveProp(NodePath.node_id, "refs", "account_id"),
+            ],
+        ),
+        ResolveAncestor(
+            "region",
+            [
+                ResolveProp(NodePath.reported_name, "metadata", "region"),
+                ResolveProp(NodePath.node_id, "refs", "region_id"),
+            ],
+        ),
+        ResolveAncestor(
+            "zone",
+            [
+                ResolveProp(NodePath.reported_name, "metadata", "zone"),
+                ResolveProp(NodePath.node_id, "refs", "zone_id"),
+            ],
+        ),
+    ]
+
+    resolved_ancestors = {
+        kind: f"{prop.section}.{prop.name}"
+        for kind, prop in {a.kind: a.resolves_id() for a in to_resolve}.items()
+        if prop
+    }

--- a/keepercore/core/util.py
+++ b/keepercore/core/util.py
@@ -22,6 +22,8 @@ from typing import (
 
 from dateutil.parser import isoparse
 
+from core.types import JsonElement
+
 log = logging.getLogger(__name__)
 
 AnyT = TypeVar("AnyT")
@@ -122,6 +124,16 @@ def if_set(x: Optional[AnyT], func: Callable[[AnyT], Any], if_not: Any = None) -
     :return: the result of the function or if_not
     """
     return func(x) if x is not None else if_not
+
+
+def value_in_path(element: JsonElement, path: list[str], idx: int = 0) -> Optional[Any]:
+    # implementation without allocations (path is not changed)
+    if len(path) == idx:
+        return element
+    elif element is None or not isinstance(element, dict):
+        return None
+    else:
+        return value_in_path(element.get(path[idx], None), path, idx + 1)
 
 
 def split_esc(s: str, delim: str) -> List[str]:

--- a/keepercore/core/util.py
+++ b/keepercore/core/util.py
@@ -126,14 +126,22 @@ def if_set(x: Optional[AnyT], func: Callable[[AnyT], Any], if_not: Any = None) -
     return func(x) if x is not None else if_not
 
 
-def value_in_path(element: JsonElement, path: list[str], idx: int = 0) -> Optional[Any]:
+def value_in_path_get(element: JsonElement, path: list[str], if_none: AnyT) -> AnyT:
+    result = value_in_path(element, path)
+    return result if result and isinstance(result, type(if_none)) else if_none
+
+
+def value_in_path(element: JsonElement, path: list[str]) -> Optional[Any]:
     # implementation without allocations (path is not changed)
-    if len(path) == idx:
-        return element
-    elif element is None or not isinstance(element, dict):
-        return None
-    else:
-        return value_in_path(element.get(path[idx], None), path, idx + 1)
+    def at_idx(current: JsonElement, idx: int) -> Optional[Any]:
+        if len(path) == idx:
+            return current
+        elif current is None or not isinstance(current, dict) or path[idx] not in current:
+            return None
+        else:
+            return at_idx(current[path[idx]], idx + 1)
+
+    return at_idx(element, 0)
 
 
 def split_esc(s: str, delim: str) -> List[str]:

--- a/keepercore/tests/core/cli/cli_test.py
+++ b/keepercore/tests/core/cli/cli_test.py
@@ -19,6 +19,7 @@ from core.db.db_access import DbAccess
 from core.db.graphdb import ArangoGraphDB
 from core.error import CLIParseError
 from core.event_bus import EventBus
+from core.model.adjust_node import NoAdjust
 from core.model.model import Model
 from core.types import JsonElement
 from core.worker_task_queue import WorkerTaskQueue, WorkerTaskDescription
@@ -42,7 +43,7 @@ def cli_deps(
     task_queue: WorkerTaskQueue,
     worker: tuple[WorkerTaskDescription, WorkerTaskDescription, WorkerTaskDescription],
 ) -> CLIDependencies:
-    db_access = DbAccess(filled_graph_db.db.db, event_bus)
+    db_access = DbAccess(filled_graph_db.db.db, event_bus, NoAdjust())
     model_handler = ModelHandlerStatic(foo_model)
     deps = CLIDependencies()
     deps.lookup = {

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -15,6 +15,7 @@ from core.db.async_arangodb import AsyncArangoDB
 from core.db.graphdb import ArangoGraphDB, GraphDB, EventGraphDB
 from core.error import ConflictingChangeInProgress, NoSuchBatchError, InvalidBatchUpdate
 from core.event_bus import EventBus, Message
+from core.model.adjust_node import NoAdjust
 from core.model.graph_access import GraphAccess, EdgeType
 from core.model.model import Model, Complex, Property
 from core.model.typed_model import to_js, from_js
@@ -199,7 +200,7 @@ def test_db() -> StandardDatabase:
 @pytest.fixture
 async def graph_db(test_db: StandardDatabase) -> ArangoGraphDB:
     async_db = AsyncArangoDB(test_db)
-    graph_db = ArangoGraphDB(async_db, "ns")
+    graph_db = ArangoGraphDB(async_db, "ns", NoAdjust())
     await graph_db.create_update_schema()
     await async_db.truncate(graph_db.in_progress)
     return graph_db

--- a/keepercore/tests/core/db/graphdb_test.py
+++ b/keepercore/tests/core/db/graphdb_test.py
@@ -89,19 +89,19 @@ def create_graph(bla_text: str, width: int = 10) -> MultiDiGraph:
         graph.add_edge(from_node, to_node, key, edge_type=edge_type)
 
     # root -> collector -> sub_root -> **rest
-    graph.add_node("root", reported=to_json(Foo("root")))
-    graph.add_node("collector", reported=to_json(Foo("root")), merge=True)
-    graph.add_node("sub_root", reported=to_json(Foo("sub_root")))
+    graph.add_node("root", reported=to_json(Foo("root")), kinds=["foo"])
+    graph.add_node("collector", reported=to_json(Foo("root")), kinds=["foo"], merge=True)
+    graph.add_node("sub_root", reported=to_json(Foo("sub_root")), kinds=["foo"])
     add_edge("root", "collector")
     add_edge("collector", "sub_root")
 
     for o in range(0, width):
         oid = str(o)
-        graph.add_node(oid, reported=to_json(Foo(oid)))
+        graph.add_node(oid, reported=to_json(Foo(oid)), kinds=["foo"])
         add_edge("sub_root", oid)
         for i in range(0, width):
             iid = f"{o}_{i}"
-            graph.add_node(iid, reported=to_json(Bla(iid, name=bla_text)))
+            graph.add_node(iid, reported=to_json(Bla(iid, name=bla_text)), kinds=["bla"])
             add_edge(oid, iid)
     return graph
 
@@ -114,7 +114,7 @@ def create_multi_collector_graph(width: int = 3) -> MultiDiGraph:
         graph.add_edge(from_node, to_node, key, edge_type=edge_type)
 
     def add_node(node_id: str, merge: bool = False) -> str:
-        graph.add_node(node_id, reported=to_json(Foo(node_id)), merge=merge)
+        graph.add_node(node_id, reported=to_json(Foo(node_id)), merge=merge, kinds=["foo"])
         return node_id
 
     root = add_node("root")

--- a/keepercore/tests/core/model/adjust_node_test.py
+++ b/keepercore/tests/core/model/adjust_node_test.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from typing import Optional
+
+from core.model.adjust_node import DirectAdjuster, NoAdjust
+from core.types import Json
+from core.util import utc_str, value_in_path
+
+
+def test_adjust_expired() -> None:
+    adjuster = DirectAdjuster()
+    created_at = datetime(2021, 1, 1)
+    expires_at = datetime(2022, 2, 1)
+
+    def expect_expires(reported: Json, expires: Optional[str]) -> None:
+        result = adjuster.adjust({"reported": reported})
+        assert value_in_path(result, ["metadata", "expires"]) == expires
+
+    # test iso datetime
+    expect_expires({"tags": {"expires": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
+    expect_expires({"tags": {"cloudkeeper:expires": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
+    expect_expires({"tags": {"expiration": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
+    expect_expires({"tags": {"cloudkeeper:expiration": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
+
+    # test duration
+    reported: Json = {"ctime": utc_str(created_at)}
+    expect_expires(reported | {"tags": {"expires": "never"}}, None)  # never can not be parsed
+    expect_expires({"tags": {"expires": "2w3d4h5m"}}, None)  # no ctime given
+    expect_expires(reported | {"tags": {"expires": "23h"}}, "2021-01-01T23:00:00Z")
+    expect_expires(reported | {"tags": {"expires": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+    expect_expires(reported | {"tags": {"cloudkeeper:expires": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+    expect_expires(reported | {"tags": {"cloudkeeper:expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+    expect_expires(reported | {"tags": {"expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+
+    # multiple values given: use order: ck:expiration -> ck:expires -> expiration -> expires
+    expect_expires(
+        reported
+        | {
+            "tags": {
+                "expires": "4h",
+                "expiration": "2021-01-01T11:20:00Z",
+                "cloudkeeper:expires": "2h",
+                "cloudkeeper:expiration": "2w3d4h5m",
+            }
+        },
+        "2021-01-18T04:05:00Z",
+    )
+
+    # no tags given
+    expect_expires({}, None)
+
+
+def test_no_adjust() -> None:
+    adjuster = NoAdjust()
+    created_at = datetime(2021, 1, 1)
+    expires_at = datetime(2022, 2, 1)
+    reported: Json = {"ctime": utc_str(created_at)}
+
+    def expect_expires(reported: Json, expires: Optional[str]) -> None:
+        result = adjuster.adjust({"reported": reported})
+        assert value_in_path(result, ["metadata", "expires"]) == expires
+
+    expect_expires({"tags": {"expires": utc_str(expires_at)}}, None)
+    expect_expires(reported | {"tags": {"cloudkeeper:expires": "2w3d4h5m"}}, None)

--- a/keepercore/tests/core/model/adjust_node_test.py
+++ b/keepercore/tests/core/model/adjust_node_test.py
@@ -11,7 +11,7 @@ from core.util import utc_str, value_in_path
 def test_adjust_expired() -> None:
     adjuster = DirectAdjuster()
     created_at = datetime(2021, 1, 1)
-    expires_at = datetime(2022, 2, 1)
+    expires_at = datetime(2022, 2, 15, 13)
 
     def expect_expires(reported: Json, expires: Optional[Union[str, Pattern[Any]]]) -> None:
         result = adjuster.adjust({"reported": reported})
@@ -23,10 +23,10 @@ def test_adjust_expired() -> None:
             assert expires.fullmatch(value_in_path(result, ["metadata", "expires"]))
 
     # test iso datetime
-    expect_expires({"tags": {"cloudkeeper:expires": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
-    expect_expires({"tags": {"cloudkeeper:expires": expires_at.isoformat()}}, re.compile("2022-01-31T.*"))
-    expect_expires({"tags": {"cloudkeeper:expires": "31.12.2022"}}, re.compile("2022-12-30.*"))
-    expect_expires({"tags": {"cloudkeeper:expires": "12/31/2022"}}, re.compile("2022-12-30.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": utc_str(expires_at)}}, "2022-02-15T13:00:00Z")
+    expect_expires({"tags": {"cloudkeeper:expires": expires_at.isoformat()}}, re.compile("2022-02-1.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": "15.02.2022"}}, re.compile("2022-02-1.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": "02/15/2022"}}, re.compile("2022-02-1.*"))
     expect_expires({"tags": {"cloudkeeper:expires": "+2d"}}, None)  # ony accept absolute time
     expect_expires({"tags": {"cloudkeeper:expires": "never"}}, None)  # never can not be parsed
 

--- a/keepercore/tests/core/model/adjust_node_test.py
+++ b/keepercore/tests/core/model/adjust_node_test.py
@@ -1,6 +1,7 @@
+import re
 from datetime import datetime
 
-from typing import Optional
+from typing import Optional, Union, Pattern, Any
 
 from core.model.adjust_node import DirectAdjuster, NoAdjust
 from core.types import Json
@@ -12,23 +13,29 @@ def test_adjust_expired() -> None:
     created_at = datetime(2021, 1, 1)
     expires_at = datetime(2022, 2, 1)
 
-    def expect_expires(reported: Json, expires: Optional[str]) -> None:
+    def expect_expires(reported: Json, expires: Optional[Union[str, Pattern[Any]]]) -> None:
         result = adjuster.adjust({"reported": reported})
-        assert value_in_path(result, ["metadata", "expires"]) == expires
+        if expires is None:
+            assert value_in_path(result, ["metadata", "expires"]) is None
+        elif isinstance(expires, str):
+            assert value_in_path(result, ["metadata", "expires"]) == expires
+        elif isinstance(expires, Pattern):
+            assert expires.fullmatch(value_in_path(result, ["metadata", "expires"]))
 
     # test iso datetime
-    expect_expires({"tags": {"expires": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
     expect_expires({"tags": {"cloudkeeper:expires": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
-    expect_expires({"tags": {"expiration": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
-    expect_expires({"tags": {"cloudkeeper:expiration": utc_str(expires_at)}}, "2022-02-01T00:00:00Z")
+    expect_expires({"tags": {"cloudkeeper:expires": expires_at.isoformat()}}, re.compile("2022-01-31T.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": "31.12.2022"}}, re.compile("2022-12-30.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": "12/31/2022"}}, re.compile("2022-12-30.*"))
+    expect_expires({"tags": {"cloudkeeper:expires": "+2d"}}, None)  # ony accept absolute time
+    expect_expires({"tags": {"cloudkeeper:expires": "never"}}, None)  # never can not be parsed
 
     # test duration
     reported: Json = {"ctime": utc_str(created_at)}
-    expect_expires(reported | {"tags": {"expires": "never"}}, None)  # never can not be parsed
-    expect_expires({"tags": {"expires": "2w3d4h5m"}}, None)  # no ctime given
-    expect_expires(reported | {"tags": {"expires": "23h"}}, "2021-01-01T23:00:00Z")
-    expect_expires(reported | {"tags": {"expires": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
-    expect_expires(reported | {"tags": {"cloudkeeper:expires": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+    expect_expires(reported | {"tags": {"expiration": "never"}}, None)  # never can not be parsed
+    expect_expires(reported | {"tags": {"cloudkeeper:expiration": "never"}}, None)  # never can not be parsed
+    expect_expires({"tags": {"cloudkeeper:expiration": "12h"}}, None)  # no ctime given
+    expect_expires({"tags": {"expiration": "2w3d4h5m"}}, None)  # no ctime given
     expect_expires(reported | {"tags": {"cloudkeeper:expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
     expect_expires(reported | {"tags": {"expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
 
@@ -37,13 +44,12 @@ def test_adjust_expired() -> None:
         reported
         | {
             "tags": {
-                "expires": "4h",
-                "expiration": "2021-01-01T11:20:00Z",
-                "cloudkeeper:expires": "2h",
+                "expiration": "2d",
+                "cloudkeeper:expires": "2021-01-01T11:20:00Z",
                 "cloudkeeper:expiration": "2w3d4h5m",
             }
         },
-        "2021-01-18T04:05:00Z",
+        "2021-01-01T11:20:00Z",
     )
 
     # no tags given

--- a/keepercore/tests/core/model/graph_access_test.py
+++ b/keepercore/tests/core/model/graph_access_test.py
@@ -9,15 +9,17 @@ from pytest import fixture
 
 from core.model.graph_access import GraphAccess, GraphBuilder, EdgeType, NodeData
 from core.model.model import Model
+from core.model.typed_model import to_js
 from tests.core.db.graphdb_test import Foo
 
 # noinspection PyUnresolvedReferences
 from tests.core.model.model_test import person_model
 
+
 FooTuple = collections.namedtuple(
     "FooTuple",
-    ["a", "b", "c", "d", "e", "f", "g"],
-    defaults=["", 0, [], "foo", {"a": 12, "b": 32}, date.fromisoformat("2021-03-29"), 1.234567],
+    ["a", "b", "c", "d", "e", "f", "g", "kind"],
+    defaults=["", 0, [], "foo", {"a": 12, "b": 32}, date.fromisoformat("2021-03-29"), 1.234567, "foo"],
 )
 
 
@@ -25,10 +27,10 @@ FooTuple = collections.namedtuple(
 @fixture
 def graph_access() -> GraphAccess:
     g = MultiDiGraph()
-    g.add_node("1", reported=FooTuple("1"), desired={"name": "a"}, metadata={"version": 1})
-    g.add_node("2", reported=FooTuple("2"), desired={"name": "b"}, metadata={"version": 2})
-    g.add_node("3", reported=FooTuple("3"), desired={"name": "c"}, metadata={"version": 3})
-    g.add_node("4", reported=FooTuple("4"), desired={"name": "d"}, metadata={"version": 4})
+    g.add_node("1", reported=to_js(FooTuple("1")), desired={"name": "a"}, metadata={"version": 1}, kinds=["foo"])
+    g.add_node("2", reported=to_js(FooTuple("2")), desired={"name": "b"}, metadata={"version": 2}, kinds=["foo"])
+    g.add_node("3", reported=to_js(FooTuple("3")), desired={"name": "c"}, metadata={"version": 3}, kinds=["foo"])
+    g.add_node("4", reported=to_js(FooTuple("4")), desired={"name": "d"}, metadata={"version": 4}, kinds=["foo"])
     g.add_edge("1", "2", "1_2_dependency", edge_type=EdgeType.dependency)
     g.add_edge("1", "3", "1_3_dependency", edge_type=EdgeType.dependency)
     g.add_edge("2", "3", "2_3_dependency", edge_type=EdgeType.dependency)
@@ -43,11 +45,20 @@ def graph_access() -> GraphAccess:
 # noinspection PyArgumentList
 def test_access_node() -> None:
     g = MultiDiGraph()
-    g.add_node("1", reported=FooTuple(a="1"))
+    g.add_node("1", reported=to_js(FooTuple(a="1")))
     access: GraphAccess = GraphAccess(g)
-    _, json, _, _, sha, _, _ = node(access, "1")
-    assert sha == "ae15ce169cbf1048cf1da6bd537eb0259437c630d45b82ce2fb2321d0b3059cd"
-    assert json == {"a": "1", "b": 0, "c": [], "d": "foo", "e": {"a": 12, "b": 32}, "f": "2021-03-29", "g": 1.234567}
+    _, json, _, _, _, sha, _, _ = node(access, "1")
+    assert sha == "4f226c613e168b79a94aa93493c3770ffc189f06a2569ce65f4a586f50682558"
+    assert json == {
+        "a": "1",
+        "b": 0,
+        "c": [],
+        "d": "foo",
+        "e": {"a": 12, "b": 32},
+        "f": "2021-03-29",
+        "g": 1.234567,
+        "kind": "foo",
+    }
     assert access.node("2") is None
 
 
@@ -64,8 +75,8 @@ def test_marshal_unmarshal() -> None:
 def test_content_hash() -> None:
     # the order of properties should not matter for the content hash
     g = MultiDiGraph()
-    g.add_node("1", reported={"a": {"a": 1, "c": 2, "b": 3}, "c": 2, "b": 3, "d": "foo", "z": True})
-    g.add_node("2", reported={"z": True, "c": 2, "b": 3, "a": {"b": 3, "c": 2, "a": 1}, "d": "foo"})  # change the order
+    g.add_node("1", reported={"a": {"a": 1, "c": 2, "b": 3}, "c": 2, "b": 3, "d": "foo", "z": True, "kind": "a"})
+    g.add_node("2", reported={"z": True, "c": 2, "b": 3, "a": {"b": 3, "c": 2, "a": 1}, "d": "foo", "kind": "a"})
 
     access = GraphAccess(g)
     sha1 = node(access, "1")[2]
@@ -82,8 +93,8 @@ def test_not_visited(graph_access: GraphAccess) -> None:
     graph_access.node("3")
     not_visited = list(graph_access.not_visited_nodes())
     assert len(not_visited) == 2
-    assert not_visited[0][4] == "4847fca1333fa8ee59f749d353f5bf5437c7fde667953d2ddfc7eca70afb24d1"
-    assert not_visited[1][4] == "2c3a5f59845c01c4acd0235aea01d6c2a63ba74f2796be4ac57c7c683abd49ca"
+    assert not_visited[0][5] == "a9efa612d3c5a231c643d0b9f9aab3297b84c7433a009e772f4692cc016927aa"
+    assert not_visited[1][5] == "28cd705c4a5378520969ab3e0ad229edda361536b581aa4a94d5f9dcdf2dcb87"
 
 
 def test_edges(graph_access: GraphAccess) -> None:
@@ -138,15 +149,16 @@ def test_builder(person_model: Model) -> None:
 def multi_cloud_graph(merge_on: str) -> MultiDiGraph:
     g = MultiDiGraph()
     root = "root"
-    g.add_node(root)
 
     def add_node(node_id: str) -> None:
-        g.add_node(node_id, merge=node_id.startswith(merge_on), reported="test")
+        reported = {"some": {"deep": {"nested": node_id}}}
+        g.add_node(node_id, merge=node_id.startswith(merge_on), reported=reported, kind=node_id, kinds=[node_id])
 
     def add_edge(from_node: str, to_node: str, edge_type: str = EdgeType.default) -> None:
         key = GraphAccess.edge_key(from_node, to_node, edge_type)
         g.add_edge(from_node, to_node, key, edge_type=edge_type)
 
+    add_node(root)
     for collector_d in ["aws", "gcp"]:
         collector = f"collector_{collector_d}"
         add_node(collector)
@@ -217,3 +229,31 @@ def test_sub_graphs_with_cycle() -> None:
     with pytest.raises(AttributeError):
         _, _, graph_it = GraphAccess.merge_graphs(graph)
         list(graph_it)
+
+
+def test_predecessors() -> None:
+    graph = GraphAccess(multi_cloud_graph("account"))
+    child = "child_parent_region_account_collector_gcp_2_europe_1_0"
+    parent = "parent_region_account_collector_gcp_2_europe_1"
+    region = "region_account_collector_gcp_2_europe"
+
+    # dependency: region -> parent -> child
+    assert list(graph.predecessors(child, EdgeType.dependency)) == [parent]
+    assert list(graph.predecessors(parent, EdgeType.dependency)) == [region]
+    assert child in list(graph.successors(parent, EdgeType.dependency))
+    assert parent in list(graph.successors(region, EdgeType.dependency))
+
+    # delete: child -> parent -> region
+    assert list(graph.successors(child, EdgeType.delete)) == [parent]
+    assert list(graph.successors(parent, EdgeType.delete)) == [region]
+    assert parent in list(graph.successors(child, EdgeType.delete))
+    assert region in list(graph.successors(parent, EdgeType.delete))
+
+
+def test_ancestor_with() -> None:
+    graph = GraphAccess(multi_cloud_graph("account"))
+    nid = "child_parent_region_account_collector_gcp_2_europe_1_0"
+    assert graph.ancestor_of(nid, EdgeType.dependency, "root") is not None
+    assert graph.ancestor_of(nid, EdgeType.delete, "root") is None
+    assert graph.ancestor_of(nid, EdgeType.dependency, "foo") is None
+    assert graph.ancestor_of(nid, EdgeType.dependency, "foo") is None

--- a/keepercore/tests/core/model/model_test.py
+++ b/keepercore/tests/core/model/model_test.py
@@ -87,6 +87,8 @@ def test_datetime() -> None:
     assert expect_error(a, True) == "Expected type datetime but got bool"
     assert a.coerce("2021-06-08T08:56:15Z") == "2021-06-08T08:56:15Z"
     assert a.coerce("2021-06-08T08:56:15.0000+00:00") == "2021-06-08T08:56:15Z"
+    assert a.coerce("2021-06-08T08:56:15.0000+02:00") == "2021-06-08T06:56:15Z"
+    assert a.coerce("2021-06-08T08:56:15.0000-02:00") == "2021-06-08T10:56:15Z"
     assert a.coerce("2021-06-08T08:56:15.0000+0000") == "2021-06-08T08:56:15Z"
     assert a.coerce("2021-06-08 08:56:15").startswith("2021-06-08T")
     assert a.coerce("2021-06-08 08:56:15").endswith(":56:15Z")  # ignore the hours, time zone dependant

--- a/keepercore/tests/core/model/resolve_in_graph_test.py
+++ b/keepercore/tests/core/model/resolve_in_graph_test.py
@@ -1,0 +1,10 @@
+from core.model.resolve_in_graph import GraphResolver
+
+
+def test_resolved_ancestors() -> None:
+    assert GraphResolver.resolved_ancestors == {
+        "account": "refs.account_id",
+        "cloud": "refs.cloud_id",
+        "region": "refs.region_id",
+        "zone": "refs.zone_id",
+    }

--- a/keepercore/tests/core/util_test.py
+++ b/keepercore/tests/core/util_test.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from aiostream import stream
 
-from core.util import AccessJson, force_gen, uuid_str
+from core.util import AccessJson, force_gen, uuid_str, value_in_path
 
 
 def test_access_json() -> None:
@@ -25,6 +25,13 @@ def test_uuid() -> None:
     assert uuid_str("foo") == uuid_str("foo")
     assert uuid_str("foo") != uuid_str("bla")
     assert uuid_str() != uuid_str()
+
+
+def test_value_in_path() -> None:
+    js = {"foo": {"bla": {"test": 123}}}
+    assert value_in_path(js, ["foo", "bla", "test"]) == 123
+    assert value_in_path(js, ["foo", "bla", "test", "bar"]) is None
+    assert value_in_path(js, ["foo", "bla", "bar"]) is None
 
 
 @pytest.mark.asyncio

--- a/keepercore/tests/core/util_test.py
+++ b/keepercore/tests/core/util_test.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from aiostream import stream
 
-from core.util import AccessJson, force_gen, uuid_str, value_in_path
+from core.util import AccessJson, force_gen, uuid_str, value_in_path, value_in_path_get
 
 
 def test_access_json() -> None:
@@ -30,8 +30,11 @@ def test_uuid() -> None:
 def test_value_in_path() -> None:
     js = {"foo": {"bla": {"test": 123}}}
     assert value_in_path(js, ["foo", "bla", "test"]) == 123
+    assert value_in_path_get(js, ["foo", "bla", "test"], "foo") == "foo"  # expected string got int -> default value
     assert value_in_path(js, ["foo", "bla", "test", "bar"]) is None
+    assert value_in_path_get(js, ["foo", "bla", "test", "bar"], 123) == 123
     assert value_in_path(js, ["foo", "bla", "bar"]) is None
+    assert value_in_path_get(js, ["foo", "bla", "bar"], "foo") == "foo"
 
 
 @pytest.mark.asyncio

--- a/keepercore/tox.ini
+++ b/keepercore/tox.ini
@@ -8,7 +8,6 @@ exclude =
 application-import-names=core tests
 
 [pytest]
-addopts= --cov=core -rs -vv
 testpaths=
   tests
 


### PR DESCRIPTION

- In order to make it very simple to filter for cloud, account, region, zone: the data is retrieved and stored with each node in the metadata section (note only the name is available, which should be enough for filtering reasons)
- the id of the related node is stored separately to enable direct fetching of additional data
- AdaptNode is introduced which is called after the node has been processed (and possibly updated) and before it is written to the database. Current use-case: interpret the expire/expiration tag 
