### PR TITLE
[keepercore] Allow queries that ensure a defined graph structure

### DIFF
--- a/keepercore/.pylintrc
+++ b/keepercore/.pylintrc
@@ -68,7 +68,8 @@ disable=
     no-self-use,
     unused-argument,
     useless-return,
-    broad-except
+    broad-except,
+    too-many-statements
 
 
 [REPORTS]

--- a/keepercore/core/db/graphdb.py
+++ b/keepercore/core/db/graphdb.py
@@ -694,7 +694,7 @@ class ArangoGraphDB(GraphDB):
                 raise AttributeError(f"Given kind does not exist: {t.kind}")
             length = str(len(bind_vars))
             bind_vars[length] = t.kind
-            return f"{cursor}.kinds ANY == @{length}"
+            return f"@{length} IN {cursor}.kinds"
 
         def term(cursor: str, ab_term: Term) -> str:
             if isinstance(ab_term, AllTerm):
@@ -779,7 +779,7 @@ class ArangoGraphDB(GraphDB):
             )
         else:  # return results
             # return all pinned parts (last result is "pinned" automatically)
-            pinned = set(map(lambda x: x[2], filter(lambda x: x[0].pinned, parts)))
+            pinned = {out for part, _, out, _ in parts if part.pinned}
             sort_by = sort("r", query.sort, section_dot) if query.sort else ""
             result = f'UNION({",".join(pinned)},{resulting_cursor})' if pinned else resulting_cursor
             return f"""{query_str} FOR r in {result}{sort_by}{limited} RETURN r""", bind_vars

--- a/keepercore/core/db/model.py
+++ b/keepercore/core/db/model.py
@@ -7,7 +7,7 @@ from core.query.model import Query
 
 
 class QueryModel(ABC):
-    def __init__(self, query: Query, model: Model, query_section: Optional[str]):
+    def __init__(self, query: Query, model: Model, query_section: Optional[str] = None):
         self.query = query
         self.model = model
         self.query_section = query_section

--- a/keepercore/core/parse_util.py
+++ b/keepercore/core/parse_util.py
@@ -38,7 +38,7 @@ equals_dp = string("=")
 integer_dp = regex(r"[+-]?[0-9]+").map(int)
 float_dp = regex(r"[+-]?[0-9]+\.[0-9]+").map(float)
 variable_dp = regex("[A-Za-z][A-Za-z0-9_.*\\[\\]]*")
-literal_dp = regex("[A-Za-z][A-Za-z0-9_\\-]*")
+literal_dp = regex("[A-Za-z0-9][A-Za-z0-9_\\-]*")
 
 string_part_dp = regex(r'[^"\\]+')
 string_esc_dp = string("\\") >> (
@@ -98,7 +98,7 @@ def json_array_parser() -> Parser:
 
 @make_parser
 def json_object_pair() -> Parser:
-    key = yield quoted_string_p
+    key = yield quoted_string_p | literal_p
     yield colon_p
     val = yield json_value_p
     return key, val

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -149,7 +149,7 @@ len_any = lexeme(string("any")).result(WithClauseFilter(">", 0))
 
 
 @make_parser
-def with_len_parser() -> Parser:
+def with_count_parser() -> Parser:
     yield count_p
     op = yield operation_p
     num = yield integer_p
@@ -160,7 +160,7 @@ def with_len_parser() -> Parser:
 def with_clause_parser() -> Parser:
     yield with_p
     yield lparen_p
-    with_filter = yield len_empty | len_any | with_len_parser
+    with_filter = yield len_empty | len_any | with_count_parser
     yield comma_p
     nav: Navigation = yield navigation_parser
     term: Optional[Term] = yield term_parser.optional()

--- a/keepercore/core/query/query_parser.py
+++ b/keepercore/core/query/query_parser.py
@@ -47,8 +47,12 @@ from core.query.model import (
     WithClause,
 )
 
-operation_p = reduce(
-    lambda x, y: x | y, [lexeme(string(a)) for a in ["<=", ">=", ">", "<", "==", "!=", "=~", "!~", "in", "not in"]]
+operation_p = (
+    reduce(
+        lambda x, y: x | y, [lexeme(string(a)) for a in ["<=", ">=", ">", "<", "==", "!=", "=~", "!~", "in", "not in"]]
+    )
+    | lexeme(string("=")).result("==")
+    | lexeme(string("~")).result("=~")
 )
 
 function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change"]])


### PR DESCRIPTION
Queries allow to easily access the graph.
Example:
```
is(account) --> is(region) 
```
Returns all regions that live under an account.

Sometimes it is desirable to query for graph nodes and ensure a certain structure without returning them.
For example: return all accounts that have 12 regions can now be expressed like this:

```
is(account) with(count==12,  --> is(region))
```

arbitrary query terms can be defined in the with clause:
```
is(account) with(empty, --> is(region) and name=="foo" or some.other.term>23)
```

with clauses can be nested:
```
is(account) with(any, --> is(region) with(empty, --> is(account) and name=="foo"))
```
