### PR TITLE
[keepercore] Aggregation: allow combined parameters

### DIFF
--- a/keepercore/core/parse_util.py
+++ b/keepercore/core/parse_util.py
@@ -39,6 +39,7 @@ integer_dp = regex(r"[+-]?[0-9]+").map(int)
 float_dp = regex(r"[+-]?[0-9]+\.[0-9]+").map(float)
 variable_dp = regex("[A-Za-z][A-Za-z0-9_.*\\[\\]]*")
 literal_dp = regex("[A-Za-z0-9][A-Za-z0-9_\\-]*")
+quote_dp = string('"')
 
 string_part_dp = regex(r'[^"\\]+')
 string_esc_dp = string("\\") >> (
@@ -53,7 +54,7 @@ string_esc_dp = string("\\") >> (
     | regex(r"u[0-9a-fA-F]{4}").map(lambda s: chr(int(s[1:], 16)))
 )
 string_part_or_esc_dp = (string_part_dp | string_esc_dp).many().concat()
-quoted_string_dp = string('"') >> string_part_or_esc_dp << string('"')
+quoted_string_dp = quote_dp >> string_part_or_esc_dp << quote_dp
 quoted_or_simple_string_dp = quoted_string_dp | literal_dp
 
 true_dp = string("true").result(True)

--- a/keepercore/core/query/model.py
+++ b/keepercore/core/query/model.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
 import abc
+from dataclasses import dataclass, field, replace
 from functools import reduce
 from typing import Mapping, Union, Optional, Any, ClassVar
 
-from dataclasses import dataclass, field, replace
 from jsons import set_deserializer
 
 from core.model.graph_access import EdgeType
@@ -325,8 +326,25 @@ class Part:
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
-class AggregateVariable:
+class AggregateVariableName:
     name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class AggregateVariableCombined:
+    parts: list[Union[str, AggregateVariableName]]
+
+    def __str__(self) -> str:
+        return "".join(p if isinstance(p, str) else f"{{{p}}}" for p in self.parts)
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class AggregateVariable:
+    # name is either a simple variable name or some combination of strings and variables like "foo_{var1}_{var2}_bla"
+    name: Union[AggregateVariableName, AggregateVariableCombined]
     as_name: Optional[str] = None
 
     def __str__(self) -> str:
@@ -334,7 +352,7 @@ class AggregateVariable:
         return f"{self.name}{with_as}"
 
     def get_as_name(self) -> str:
-        return self.as_name if self.as_name else self.name
+        return self.as_name if self.as_name else str(self.name)
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)


### PR DESCRIPTION
This change allows for creating combined aggregation variables.

Example:
```
aggregate("{account.name} ({account.id})" as account: sum(reservations) as reserved_instances_total) (merge_with_ancestors="account"): is("instance_type")
```

For every matching element, a string is created with this template and used as aggregation variable. The result could look like this:
```
[
    {
        "group": {"account": "pumpkin (123512331213)"},
        "reserved_instances_total": 23
    },
    {
        "group": {"account": "demo (123512331212)"},
        "reserved_instances_total": 12
    }
]
```

Fixes #154