### PR TITLE
[cksh] Request text/plain instead of application/yaml

### DIFF
--- a/cksh/cksh/__main__.py
+++ b/cksh/cksh/__main__.py
@@ -19,7 +19,6 @@ def main() -> None:
     session = PromptSession(history=history)
     execute_endpoint = f"{ArgumentParser.args.keepercore_uri}/cli/execute"
     shutdown_event = Event()
-    headers = {"Content-type": "application/yaml"}
 
     while not shutdown_event.is_set():
         try:
@@ -31,7 +30,10 @@ def main() -> None:
                 continue
 
             r = requests.post(
-                execute_endpoint, data=cli_input, headers=headers, stream=True
+                execute_endpoint,
+                data=cli_input,
+                headers={"Content-type": "text/plain"},
+                stream=True,
             )
             if r.status_code != 200:
                 print(r.text, file=sys.stderr)

--- a/cksh/cksh/__main__.py
+++ b/cksh/cksh/__main__.py
@@ -62,11 +62,11 @@ def main() -> None:
 
 
 def update_headers_with_terminal_size(headers: Dict[str, str]) -> None:
-    tty_columns, tty_lines = shutil.get_terminal_size(fallback=(80, 20))
+    tty_columns, tty_rows = shutil.get_terminal_size(fallback=(80, 20))
     headers.update(
         {
             "Cloudkeeper-Cksh-Columns": str(tty_columns),
-            "Cloudkeeper-Cksh-Lines": str(tty_lines),
+            "Cloudkeeper-Cksh-Rows": str(tty_rows),
         }
     )
 


### PR DESCRIPTION
- Request text/plain instead of application/yaml
- Submit tty columns/rows headers for server side output formatting
- Add `--stdin` arg for reading commands from stdin instead of starting an interactive terminal session