### PR TITLE
[keepercore] A more generous unquoted string parser

### DIFF
--- a/keepercore/core/parse_util.py
+++ b/keepercore/core/parse_util.py
@@ -1,6 +1,15 @@
+import re
 from typing import Callable
 
+import parsy
 from parsy import Parser, generate, regex, string
+
+
+def make_direct_parser(fn: Callable[[str, int], parsy.Result]) -> Parser:
+    """
+    Make typed parser (required for mypy).
+    """
+    return Parser(fn)
 
 
 def make_parser(fn: Callable[[], Parser]) -> Parser:
@@ -39,8 +48,33 @@ integer_dp = regex(r"[+-]?[0-9]+").map(int)
 float_dp = regex(r"[+-]?[0-9]+\.[0-9]+").map(float)
 variable_dp = regex("[A-Za-z][A-Za-z0-9_.*\\[\\]]*")
 literal_dp = regex("[A-Za-z0-9][A-Za-z0-9_\\-]*")
-quote_dp = string('"')
 
+allowed_characters = re.compile("[A-Za-z0-9_\\-:]")
+end_of_unquoted_str = re.compile("[\\[\\])(}{\\s]")
+
+
+@make_direct_parser
+def unquoted_string_parser(stream: str, index: int) -> parsy.Result:
+    # read from index until -> end_of_unquoted_str
+    # all characters in between have to be allowed characters
+    # there has to be at least one alpha character (to not read numbers as strings)
+    start = index
+    found_alpha = False
+    valid_string_chars = True
+    # look ahead to next delimiter
+    while index < len(stream) and valid_string_chars and not end_of_unquoted_str.match(stream[index]):
+        found_alpha = str.isalpha(stream[index]) if not found_alpha else found_alpha
+        valid_string_chars = allowed_characters.match(stream[index]) is not None
+        index += 1
+
+    if index <= len(stream) and valid_string_chars and found_alpha:
+        return parsy.Result.success(index, stream[start:index])
+    else:
+        return parsy.Result.failure(index, "A-Za-z0-9_-:")
+
+
+unquoted_string_dp = unquoted_string_parser
+quote_dp = string('"')
 string_part_dp = regex(r'[^"\\]+')
 string_esc_dp = string("\\") >> (
     string("\\")
@@ -55,7 +89,7 @@ string_esc_dp = string("\\") >> (
 )
 string_part_or_esc_dp = (string_part_dp | string_esc_dp).many().concat()
 quoted_string_dp = quote_dp >> string_part_or_esc_dp << quote_dp
-quoted_or_simple_string_dp = quoted_string_dp | literal_dp
+quoted_or_simple_string_dp = quoted_string_dp | unquoted_string_dp
 
 true_dp = string("true").result(True)
 false_dp = string("false").result(False)
@@ -85,6 +119,7 @@ integer_p = lexeme(integer_dp)
 variable_p = lexeme(variable_dp)
 literal_p = lexeme(literal_dp)
 quoted_string_p = lexeme(quoted_string_dp)
+unquoted_string_p = lexeme(unquoted_string_dp)
 
 # endregion
 
@@ -110,11 +145,11 @@ json_value_dp = (
     quoted_string_dp
     | json_array_parser
     | json_object
-    | float_dp
-    | integer_dp
     | true_dp
     | false_dp
     | null_dp
-    | literal_dp
+    | unquoted_string_dp
+    | float_dp
+    | integer_dp
 )
 json_value_p = lexeme(json_value_dp)

--- a/keepercore/tests/core/query/query_parser_test.py
+++ b/keepercore/tests/core/query/query_parser_test.py
@@ -223,6 +223,7 @@ def test_limit() -> None:
 
 
 def test_with_clause() -> None:
+    predicate_term.parse("foo == bla")
     wc: WithClause = with_clause_parser.parse("with(empty, -delete-> foo == bla and test > 23 with(any, -delete->))")
     assert wc.with_filter == WithClauseFilter("==", 0)
     assert wc.navigation == Navigation(edge_type="delete")


### PR DESCRIPTION
This change introduces an unquoted string parser that allows timestamps to be entered without quotes