### PR TITLE
[ckcore] Make resolved ancestor attributes available under metadata.ancestors.

### DIFF
--- a/ckcore/core/model/graph_access.py
+++ b/ckcore/core/model/graph_access.py
@@ -12,7 +12,7 @@ from core.model.resolve_in_graph import GraphResolver, NodePath, ResolveProp
 from core.model.model import Model
 from core.model.typed_model import to_js
 from core.types import Json
-from core.util import utc, utc_str, value_in_path
+from core.util import utc, utc_str, value_in_path, set_value_in_path
 
 
 class Section:
@@ -221,9 +221,7 @@ class GraphAccess:
         def with_ancestor(ancestor: Json, prop: ResolveProp) -> None:
             extracted = value_in_path(ancestor, prop.extract_path)
             if extracted:
-                if prop.section not in node:
-                    node[prop.section] = {}
-                node[prop.section][prop.name] = extracted
+                set_value_in_path(extracted, prop.to_path, node)
 
         for resolver in GraphResolver.to_resolve:
             # search for ancestor that matches filter criteria

--- a/ckcore/core/model/resolve_in_graph.py
+++ b/ckcore/core/model/resolve_in_graph.py
@@ -17,10 +17,9 @@ class NodePath:
 class ResolveProp:
     # Path to the property that needs to be extracted
     extract_path: list[str]
-    # section to write the result (e.g. metadata, refs etc)
-    section: str
-    # name of property in section
-    name: str
+
+    # Path to write this property to
+    to_path: list[str]
 
 
 @dataclass(frozen=True)
@@ -38,39 +37,47 @@ class ResolveAncestor:
 
 
 class GraphResolver:
+    """
+    Resolve common properties from the structure of the graph and make them available
+    as properties on the node. This way the data does not have to be looked up in the hierarchy
+    but can be queried directly.
+    """
+
     to_resolve = [
         ResolveAncestor(
             "cloud",
             [
-                ResolveProp(NodePath.reported_name, "metadata", "cloud"),
-                ResolveProp(NodePath.node_id, "refs", "cloud_id"),
+                ResolveProp(NodePath.reported_name, ["metadata", "ancestors", "cloud", "name"]),
+                ResolveProp(NodePath.reported_id, ["metadata", "ancestors", "cloud", "id"]),
+                ResolveProp(NodePath.node_id, ["refs", "cloud_id"]),
             ],
         ),
         ResolveAncestor(
             "account",
             [
-                ResolveProp(NodePath.reported_name, "metadata", "account"),
-                ResolveProp(NodePath.node_id, "refs", "account_id"),
+                ResolveProp(NodePath.reported_name, ["metadata", "ancestors", "account", "name"]),
+                ResolveProp(NodePath.reported_id, ["metadata", "ancestors", "account", "id"]),
+                ResolveProp(NodePath.node_id, ["refs", "account_id"]),
             ],
         ),
         ResolveAncestor(
             "region",
             [
-                ResolveProp(NodePath.reported_name, "metadata", "region"),
-                ResolveProp(NodePath.node_id, "refs", "region_id"),
+                ResolveProp(NodePath.reported_name, ["metadata", "ancestors", "region", "name"]),
+                ResolveProp(NodePath.reported_id, ["metadata", "ancestors", "region", "id"]),
+                ResolveProp(NodePath.node_id, ["refs", "region_id"]),
             ],
         ),
         ResolveAncestor(
             "zone",
             [
-                ResolveProp(NodePath.reported_name, "metadata", "zone"),
-                ResolveProp(NodePath.node_id, "refs", "zone_id"),
+                ResolveProp(NodePath.reported_name, ["metadata", "ancestors", "zone", "name"]),
+                ResolveProp(NodePath.reported_id, ["metadata", "ancestors", "zone", "id"]),
+                ResolveProp(NodePath.node_id, ["refs", "zone_id"]),
             ],
         ),
     ]
 
     resolved_ancestors = {
-        kind: f"{prop.section}.{prop.name}"
-        for kind, prop in {a.kind: a.resolves_id() for a in to_resolve}.items()
-        if prop
+        kind: ".".join(prop.to_path) for kind, prop in {a.kind: a.resolves_id() for a in to_resolve}.items() if prop
     }


### PR DESCRIPTION
Example:
```
> reported is(gcp_instance) limit 1
reported:
  kind: gcp_instance
  id: '123123123'
  tags: {}
  name: agent1
  ctime: '2018-04-20T01:31:04Z'
  instance_cores: 2
  instance_memory: 7.5
  instance_type: n1-standard-2
  instance_status: terminated
  link: https://www.googleapis.com/compute/v1/projects/fooo/zones/us-central1-c/instances/agent1
  label_fingerprint: 42WmSpB8rSM=
metadata:
  ancestors:
    cloud:
      name: gcp
      id: gcp
    account:
      name: foo-support
      id: foo-support
    region:
      name: us-central1
      id: '1000'
    zone:
      name: us-central1-c
      id: '2002'
kinds:
- instance
- resource
- gcp_instance
- gcp_resource
```