### PR TITLE
[ckcore] Introduce kind command

### DIFF
--- a/ckcore/core/cli/command.py
+++ b/ckcore/core/cli/command.py
@@ -420,7 +420,7 @@ class UniqCommand(CLICommand):
         return lambda in_stream: stream.filter(in_stream, has_not_seen)
 
 
-class KindCommand(CLISource):
+class KindSource(CLISource):
     """
     Usage: kind [-p property_path] [name_of_kind]
 
@@ -485,7 +485,7 @@ class KindCommand(CLISource):
 
         def with_dependencies(model: Model) -> Stream:
             if show_kind:
-                result = kind_to_js(model[show_kind]) if arg in model else f"No kind with this name: {show_kind}"
+                result = kind_to_js(model[show_kind]) if show_kind in model else f"No kind with this name: {show_kind}"
             elif show_path:
                 result = kind_to_js(model.kind_by_path(Section.without_section(show_path)))
             else:
@@ -1153,6 +1153,7 @@ def all_sources(d: CLIDependencies) -> list[CLISource]:
         ExecuteQuerySource(d),
         JobsSource(d),
         JsonSource(d),
+        KindSource(d),
         SleepSource(d),
         StartTaskSource(d),
         TasksSource(d),
@@ -1171,7 +1172,6 @@ def all_commands(d: CLIDependencies) -> list[CLICommand]:
         FlattenCommand(d),
         FormatCommand(d),
         HeadCommand(d),
-        KindCommand(d),
         ProtectCommand(d),
         SetDesiredCommand(d),
         SetMetadataCommand(d),

--- a/ckcore/core/model/graph_access.py
+++ b/ckcore/core/model/graph_access.py
@@ -41,7 +41,7 @@ class Section:
     all = set(all_ordered)
 
     # remove the section plus dot if it exists in the string: reported.foo => foo
-    __no_section = re.compile("^(" + "|".join(f"({s})" for s in all) + ")[.]")
+    __no_section = re.compile("^(" + "|".join(f"({s})" for s in all_ordered) + ")[.]")
 
     @classmethod
     def without_section(cls, path: str) -> str:

--- a/ckcore/core/model/graph_access.py
+++ b/ckcore/core/model/graph_access.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from functools import reduce
 from typing import Optional, Generator, Any
 
@@ -38,6 +39,13 @@ class Section:
     # The set of all allowed sections
     all_ordered = [reported, desired, metadata]
     all = set(all_ordered)
+
+    # remove the section plus dot if it exists in the string: reported.foo => foo
+    __no_section = re.compile("^(" + "|".join(f"({s})" for s in all) + ")[.]")
+
+    @classmethod
+    def without_section(cls, path: str) -> str:
+        return cls.__no_section.sub("", path, 1)
 
 
 class EdgeType:

--- a/ckcore/core/model/model_handler.py
+++ b/ckcore/core/model/model_handler.py
@@ -6,7 +6,7 @@ from plantuml import PlantUML
 
 from core.async_extensions import run_async
 from core.db.modeldb import ModelDb
-from core.model.model import Model, Kind, Complex
+from core.model.model import Model, Kind, ComplexKind
 from core.util import exist
 
 log = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class ModelHandlerDB(ModelHandler):
         def edge_visible(edge: tuple[str, str]) -> bool:
             return node_visible(edge[0]) and node_visible(edge[1])
 
-        def class_node(cpx: Complex) -> str:
+        def class_node(cpx: ComplexKind) -> str:
             props = "\n".join([f"+ {p.name}: {p.kind}" for p in cpx.properties])
             return f"class {cpx.fqn} {{\n{props}\n}}"
 

--- a/ckcore/core/web/api.py
+++ b/ckcore/core/web/api.py
@@ -624,7 +624,7 @@ class Api:
                 sep = "---\n" if flag else ""
                 flag = True
                 js = to_js(item)
-                if isinstance(js, dict):
+                if isinstance(js, (dict, list)):
                     yml = yaml.dump(to_result(js), default_flow_style=False, sort_keys=False)
                     await response.write(f"{sep}{yml}".encode("utf-8"))
                 else:

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -13,6 +13,7 @@ from core.cli.cli import CLI, CLIDependencies
 from core.cli.command import ListSink
 from core.db.jobdb import JobDb
 from core.error import CLIParseError
+from core.model.model import predefined_kinds
 from core.task.task_description import TimeTrigger, Workflow
 from core.task.task_handler import TaskHandler
 from core.types import Json
@@ -302,3 +303,16 @@ async def test_tasks_command(cli: CLI, task_handler: TaskHandler, test_workflow:
     assert len(result[0]) == 1
     task = AccessJson(result[0][0])
     assert task.descriptor.id == "test_workflow"
+
+
+@pytest.mark.asyncio
+async def test_kind_command(cli: CLI) -> None:
+    result = await cli.execute_cli_command("kind", stream.list)
+    for kind in predefined_kinds:
+        assert kind.fqn in result[0][0]
+    result = await cli.execute_cli_command("kind string", stream.list)
+    assert result[0][0] == {"name": "string", "runtime_kind": "string"}
+    result = await cli.execute_cli_command("kind -p reported.ctime", stream.list)
+    assert result[0][0] == {"name": "datetime", "runtime_kind": "datetime"}
+    with pytest.raises(Exception):
+        await cli.execute_cli_command("kind foo bla bar", stream.list)

--- a/ckcore/tests/core/db/graphdb_test.py
+++ b/ckcore/tests/core/db/graphdb_test.py
@@ -17,7 +17,7 @@ from core.error import ConflictingChangeInProgress, NoSuchBatchError, InvalidBat
 from core.event_bus import EventBus, Message
 from core.model.adjust_node import NoAdjust
 from core.model.graph_access import GraphAccess, EdgeType
-from core.model.model import Model, Complex, Property
+from core.model.model import Model, ComplexKind, Property
 from core.model.typed_model import to_js, from_js
 from core.query.model import Query, P, Navigation
 from core.query.query_parser import parse_query
@@ -159,7 +159,7 @@ def create_multi_collector_graph(width: int = 3) -> MultiDiGraph:
 
 @pytest.fixture
 def foo_model() -> Model:
-    base = Complex(
+    base = ComplexKind(
         "base",
         [],
         [
@@ -167,7 +167,7 @@ def foo_model() -> Model:
             Property("kind", "string", required=True),
         ],
     )
-    foo = Complex(
+    foo = ComplexKind(
         "foo",
         ["base"],
         [
@@ -178,7 +178,7 @@ def foo_model() -> Model:
             Property("ctime", "datetime"),
         ],
     )
-    bla = Complex(
+    bla = ComplexKind(
         "bla",
         ["base"],
         [

--- a/ckcore/tests/core/db/modeldb_test.py
+++ b/ckcore/tests/core/db/modeldb_test.py
@@ -8,7 +8,7 @@ from core.db.async_arangodb import AsyncArangoDB
 from core.db.modeldb import ModelDb, EventModelDb
 from core.db.entitydb import EventEntityDb
 from core.event_bus import EventBus, Message
-from core.model.model import Complex, Property, StringKind, NumberKind, BooleanKind, Kind
+from core.model.model import ComplexKind, Property, StringKind, NumberKind, BooleanKind, Kind
 
 # noinspection PyUnresolvedReferences
 from tests.core.event_bus_test import event_bus, all_events
@@ -22,7 +22,7 @@ def test_model() -> list[Kind]:
     string_kind = StringKind("some.string", 0, 3, "\\w+")
     int_kind = NumberKind("some.int", "int32", 0, 100)
     bool_kind = BooleanKind("some.bool")
-    base = Complex(
+    base = ComplexKind(
         "base",
         [],
         [
@@ -30,7 +30,7 @@ def test_model() -> list[Kind]:
             Property("kind", "string", required=True),
         ],
     )
-    foo = Complex(
+    foo = ComplexKind(
         "foo",
         ["base"],
         [
@@ -40,7 +40,7 @@ def test_model() -> list[Kind]:
             Property("now_is", "datetime"),
         ],
     )
-    bla = Complex(
+    bla = ComplexKind(
         "bla",
         ["base"],
         [


### PR DESCRIPTION
```
    Usage: kind [-p property_path] [name_of_kind]

    kind gives information about the graph data kinds.

    Use case 1: show all available kinds:
    $> kind
    This will list all available kinds and print the name as list.

    Use case 2: show all details about a specific kind:
    $> kind graph_root
    This will show all available information about the given kind.

    Use case 3: I want to know the kind of a property in my model
    $> kind reported.tags.owner
    Lookup the type of the given property in the model.
    Assume a complex model A with reported properties: name:string, tags:dictionary[string, string]
    A lookup of property name reported.tags.owner will yield the type string
```