### PR TITLE
Use generic GraphDB args

### DIFF
--- a/docker/bootstrap-graphdb
+++ b/docker/bootstrap-graphdb
@@ -17,7 +17,7 @@ while [ $is_up = false ]; do
     fi
 done
 
-echo "Creating $CKCORE_GRAPHDB_LOGIN user and $CKCORE_GRAPHDB_DATABASE database"
+echo "Creating $CKCORE_GRAPHDB_LOGIN user and $CKCORE_GRAPHDB_DATABASE database if they do not yet exist."
 cat <<EOF | arangosh --console.history false --server.password "$GRAPHDB_ROOT_PASSWORD" > /dev/null 2>&1
 const users = require('@arangodb/users');
 users.save('$CKCORE_GRAPHDB_LOGIN', '$CKCORE_GRAPHDB_PASSWORD');

--- a/docker/supervisor.conf.in/ckcore.conf
+++ b/docker/supervisor.conf.in/ckcore.conf
@@ -1,7 +1,7 @@
 [program:ckcore]
 user=cloudkeeper
 environment=HOME="/home/cloudkeeper",USER="cloudkeeper",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-command=/usr/local/bin/ckcore -s "@CKCORE_GRAPHDB_SERVER@" -db "@CKCORE_GRAPHDB_DATABASE@" -u "@CKCORE_GRAPHDB_LOGIN@" -p "@CKCORE_GRAPHDB_PASSWORD@"
+command=/usr/local/bin/ckcore --graphdb-server "@CKCORE_GRAPHDB_SERVER@" --graphdb-database "@CKCORE_GRAPHDB_DATABASE@" --graphdb-username "@CKCORE_GRAPHDB_LOGIN@" --graphdb-password "@CKCORE_GRAPHDB_PASSWORD@"
 stdout_syslog=true
 stderr_syslog=true
 stdout_logfile_maxbytes=1MB


### PR DESCRIPTION
The current GraphDB backend is ArangoDB with plans to add more. Instead of using `--arangodb-server` as a main arg to ckcore we should use a more generic one like `--graphdb-server` and then have a selector like `--graphdb-type arangodb` to choose the backend type. That way we're not going to end up with multiple redundant args like `--arangodb-server --neo4j-server --orientdb-server --dgraph-server` and their `*-username *-password *-database` equivalents.