### PR TITLE
Blast Radius UI and cleanup

### DIFF
--- a/ckui/src/assets/graphics/1px.png.import
+++ b/ckui/src/assets/graphics/1px.png.import
@@ -28,11 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true
 svg/scale=1.0
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d63eae78f4f0315a28f7feb1c4144a7ba2dbdf164ad833aea5d0a80bd301909
-size 687

--- a/ckui/src/assets/graphics/co2_label_s_outline.png.import
+++ b/ckui/src/assets/graphics/co2_label_s_outline.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/icon_code.png.import
+++ b/ckui/src/assets/graphics/icons/icon_code.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/icon_dashboard.png.import
+++ b/ckui/src/assets/graphics/icons/icon_dashboard.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/icon_dropdown.png.import
+++ b/ckui/src/assets/graphics/icons/icon_dropdown.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/icon_nodes.png.import
+++ b/ckui/src/assets/graphics/icons/icon_nodes.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/icon_search.png.import
+++ b/ckui/src/assets/graphics/icons/icon_search.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/outline_add_box_white_24dp.png.import
+++ b/ckui/src/assets/graphics/icons/outline_add_box_white_24dp.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/outline_delete_white_24dp.png.import
+++ b/ckui/src/assets/graphics/icons/outline_delete_white_24dp.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/outline_play_arrow_white_24dp.png.import
+++ b/ckui/src/assets/graphics/icons/outline_play_arrow_white_24dp.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/icons/outline_share_white_24dp.png.import
+++ b/ckui/src/assets/graphics/icons/outline_share_white_24dp.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/leaf.png.import
+++ b/ckui/src/assets/graphics/leaf.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/leaf_outlines.png.import
+++ b/ckui/src/assets/graphics/leaf_outlines.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/min_max_circle.png.import
+++ b/ckui/src/assets/graphics/min_max_circle.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/min_max_circle_bg.png.import
+++ b/ckui/src/assets/graphics/min_max_circle_bg.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/noise.png.import
+++ b/ckui/src/assets/graphics/noise.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/extra_border.png.import
+++ b/ckui/src/assets/graphics/sci-fi/extra_border.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/extra_border2.png.import
+++ b/ckui/src/assets/graphics/sci-fi/extra_border2.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/extra_border_dots.png.import
+++ b/ckui/src/assets/graphics/sci-fi/extra_border_dots.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/icon_dropdown.png.import
+++ b/ckui/src/assets/graphics/sci-fi/icon_dropdown.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/small-crosses_repeat.png.import
+++ b/ckui/src/assets/graphics/sci-fi/small-crosses_repeat.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/small_pixels.png.import
+++ b/ckui/src/assets/graphics/sci-fi/small_pixels.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/xsmall-crosses_repeat.png.import
+++ b/ckui/src/assets/graphics/sci-fi/xsmall-crosses_repeat.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/sci-fi/xsmall_pixels.png.import
+++ b/ckui/src/assets/graphics/sci-fi/xsmall_pixels.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/search_clear_thin.png.import
+++ b/ckui/src/assets/graphics/search_clear_thin.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/search_clear_thin_s.png.import
+++ b/ckui/src/assets/graphics/search_clear_thin_s.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/spaceship_appear.png.import
+++ b/ckui/src/assets/graphics/spaceship_appear.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/spotlight_1.png.import
+++ b/ckui/src/assets/graphics/spotlight_1.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/graphics/trail.png.import
+++ b/ckui/src/assets/graphics/trail.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/ckui/src/assets/graphics/user_icon.png.import
+++ b/ckui/src/assets/graphics/user_icon.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/ckui/src/assets/shaders/time-graph-bar.tres
+++ b/ckui/src/assets/shaders/time-graph-bar.tres
@@ -1,6 +1,6 @@
 [gd_resource type="ShaderMaterial" load_steps=2 format=2]
 
-[sub_resource type="Shader" id=7]
+[sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
 render_mode unshaded;
 
@@ -10,4 +10,4 @@ void fragment() {
 }"
 
 [resource]
-shader = SubResource( 7 )
+shader = SubResource( 1 )

--- a/ckui/src/assets/themes/default.tres
+++ b/ckui/src/assets/themes/default.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Theme" load_steps=4 format=2]
 
-[sub_resource type="StyleBoxFlat" id=2]
+[sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.447059, 0.898039, 1, 0.513726 )
 border_width_left = 2
 border_width_top = 2
@@ -13,7 +13,7 @@ corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 corner_detail = 1
 
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxFlat" id=2]
 bg_color = Color( 0.447059, 0.898039, 1, 0.8 )
 border_width_left = 2
 border_width_top = 2
@@ -26,7 +26,7 @@ corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 corner_detail = 1
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id=3]
 content_margin_left = 10.0
 content_margin_right = 10.0
 content_margin_top = 0.0
@@ -44,8 +44,8 @@ corner_radius_bottom_left = 4
 corner_detail = 1
 
 [resource]
-VScrollBar/styles/grabber = SubResource( 2 )
-VScrollBar/styles/grabber_highlight = SubResource( 3 )
-VScrollBar/styles/grabber_pressed = SubResource( 3 )
-VScrollBar/styles/scroll = SubResource( 1 )
-VScrollBar/styles/scroll_focus = SubResource( 1 )
+VScrollBar/styles/grabber = SubResource( 1 )
+VScrollBar/styles/grabber_highlight = SubResource( 2 )
+VScrollBar/styles/grabber_pressed = SubResource( 2 )
+VScrollBar/styles/scroll = SubResource( 3 )
+VScrollBar/styles/scroll_focus = SubResource( 3 )

--- a/ckui/src/assets/themes/default.tres
+++ b/ckui/src/assets/themes/default.tres
@@ -1,30 +1,6 @@
-[gd_resource type="Theme" load_steps=6 format=2]
+[gd_resource type="Theme" load_steps=2 format=2]
 
-[sub_resource type="StyleBoxFlat" id=4]
-bg_color = Color( 0, 1, 0.996078, 0.207843 )
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color( 0, 1, 0.996078, 0 )
-corner_radius_top_left = 6
-corner_radius_top_right = 6
-corner_radius_bottom_right = 6
-corner_radius_bottom_left = 6
-
-[sub_resource type="StyleBoxFlat" id=5]
-bg_color = Color( 0, 1, 0.996078, 0.470588 )
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color( 0, 1, 0.996078, 0 )
-corner_radius_top_left = 6
-corner_radius_top_right = 6
-corner_radius_bottom_right = 6
-corner_radius_bottom_left = 6
-
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 10.0
 content_margin_right = 10.0
 content_margin_top = 0.0
@@ -40,17 +16,9 @@ corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
-[sub_resource type="DynamicFontData" id=1]
-font_path = "GemunuLibre-Light.ttf"
-
-[sub_resource type="DynamicFont" id=2]
-size = 26
-font_data = SubResource( 1 )
-
 [resource]
-default_font = SubResource( 2 )
-VScrollBar/styles/grabber = SubResource( 4 )
-VScrollBar/styles/grabber_highlight = SubResource( 5 )
-VScrollBar/styles/grabber_pressed = SubResource( 5 )
-VScrollBar/styles/scroll = SubResource( 3 )
-VScrollBar/styles/scroll_focus = SubResource( 3 )
+VScrollBar/styles/grabber = null
+VScrollBar/styles/grabber_highlight = null
+VScrollBar/styles/grabber_pressed = null
+VScrollBar/styles/scroll = SubResource( 1 )
+VScrollBar/styles/scroll_focus = SubResource( 1 )

--- a/ckui/src/assets/themes/default.tres
+++ b/ckui/src/assets/themes/default.tres
@@ -1,4 +1,30 @@
-[gd_resource type="Theme" load_steps=2 format=2]
+[gd_resource type="Theme" load_steps=4 format=2]
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 0.447059, 0.898039, 1, 0.513726 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.8, 0.8, 0.8, 0 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 1
+
+[sub_resource type="StyleBoxFlat" id=3]
+bg_color = Color( 0.447059, 0.898039, 1, 0.8 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.8, 0.8, 0.8, 0 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 1
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 10.0
@@ -11,14 +37,15 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0, 1, 0.996078, 0.207843 )
-corner_radius_top_left = 6
-corner_radius_top_right = 6
-corner_radius_bottom_right = 6
-corner_radius_bottom_left = 6
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 1
 
 [resource]
-VScrollBar/styles/grabber = null
-VScrollBar/styles/grabber_highlight = null
-VScrollBar/styles/grabber_pressed = null
+VScrollBar/styles/grabber = SubResource( 2 )
+VScrollBar/styles/grabber_highlight = SubResource( 3 )
+VScrollBar/styles/grabber_pressed = SubResource( 3 )
 VScrollBar/styles/scroll = SubResource( 1 )
 VScrollBar/styles/scroll_focus = SubResource( 1 )

--- a/ckui/src/icon.png.import
+++ b/ckui/src/icon.png.import
@@ -28,7 +28,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
-process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/ckui/src/project.godot
+++ b/ckui/src/project.godot
@@ -10,9 +10,9 @@ config_version=4
 
 _global_script_classes=[ {
 "base": "Node",
-"class": "CloudConnection",
+"class": "CloudEdge",
 "language": "GDScript",
-"path": "res://scripts/classes/class_cloud_connection.gd"
+"path": "res://scripts/classes/class_cloud_edge.gd"
 }, {
 "base": "Node",
 "class": "CloudGraph",
@@ -30,7 +30,7 @@ _global_script_classes=[ {
 "path": "res://scripts/tools/utils.gd"
 } ]
 _global_script_class_icons={
-"CloudConnection": "",
+"CloudEdge": "",
 "CloudGraph": "",
 "CloudNode": "",
 "Utils": ""

--- a/ckui/src/project.godot
+++ b/ckui/src/project.godot
@@ -15,6 +15,11 @@ _global_script_classes=[ {
 "path": "res://scripts/classes/class_cloud_connection.gd"
 }, {
 "base": "Node",
+"class": "CloudGraph",
+"language": "GDScript",
+"path": "res://scripts/classes/class_cloud_graph.gd"
+}, {
+"base": "Node",
 "class": "CloudNode",
 "language": "GDScript",
 "path": "res://scripts/classes/class_cloud_node.gd"
@@ -26,6 +31,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "CloudConnection": "",
+"CloudGraph": "",
 "CloudNode": "",
 "Utils": ""
 }
@@ -50,8 +56,8 @@ gdscript/warnings/return_value_discarded=false
 
 window/size/width=1920
 window/size/height=1080
-window/size/test_width=1440
-window/size/test_height=810
+window/size/test_width=1920
+window/size/test_height=1080
 window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"

--- a/ckui/src/scripts/classes/class_cloud_edge.gd
+++ b/ckui/src/scripts/classes/class_cloud_edge.gd
@@ -5,3 +5,8 @@ var from : CloudNode = null
 var to : CloudNode = null
 var line : Line2D = null
 var color := Color(0.7,0.9,1,0.1)
+
+func clone(original : CloudEdge):
+	color = original.color
+	from = original.from
+	to = original.to

--- a/ckui/src/scripts/classes/class_cloud_edge.gd
+++ b/ckui/src/scripts/classes/class_cloud_edge.gd
@@ -1,5 +1,5 @@
 extends Node
-class_name CloudConnection
+class_name CloudEdge
 
 var from : CloudNode = null
 var to : CloudNode = null

--- a/ckui/src/scripts/classes/class_cloud_graph.gd
+++ b/ckui/src/scripts/classes/class_cloud_graph.gd
@@ -5,7 +5,7 @@ signal order_done
 
 var graph_data := {
 	"nodes" : {},
-	"connections" : {}
+	"edges" : {}
 	}
 
 const ATTRACTION_CONSTANT := 0.3*0.05
@@ -41,7 +41,7 @@ func create_graph(raw_data : Dictionary):
 			graph_data.nodes[data.from].to.append( graph_data.nodes[data.to].icon )
 			graph_data.nodes[data.to].from.append( graph_data.nodes[data.from].icon )
 			# For connection lines
-			graph_data.connections[str(data.from + data.to)] = add_connection(data)
+			graph_data.edges[str(data.from + data.to)] = add_connection(data)
 
 
 func create_new_node(_data:Dictionary) -> CloudNode:
@@ -74,7 +74,7 @@ func add_connection(_data:Dictionary) -> CloudConnection:
 
 func show_connected_nodes(node_id):
 	var nodes_to_activate = [node_id]
-	for connection in graph_data.connections.values():
+	for connection in graph_data.edges.values():
 		if connection.from.id == node_id and !nodes_to_activate.has(connection.to.id):
 			nodes_to_activate.append(connection.to.id)
 		elif connection.to.id == node_id and !nodes_to_activate.has(connection.from.id):
@@ -101,7 +101,7 @@ func graph_rand_layout():
 
 
 func update_connection_lines() -> void:
-	for connection in graph_data.connections.values():
+	for connection in graph_data.edges.values():
 		connection.line.global_position = connection.from.icon.global_position
 		connection.line.points = PoolVector2Array( [Vector2.ZERO, connection.to.icon.global_position - connection.line.global_position ] )
 
@@ -124,7 +124,7 @@ func get_random_pos() -> Vector2:
 
 
 func hovering_node(node_id, power) -> void:
-	for connection in graph_data.connections.values():
+	for connection in graph_data.edges.values():
 		if connection.to.id == node_id or connection.from.id == node_id:
 			var line_color = Color(5,3,1,1) if connection.to.id == node_id else Color(3,4,5,1)
 			connection.line.self_modulate = lerp(Color.white, line_color*1.5, power)
@@ -211,17 +211,17 @@ func center_diagram():
 func get_cloudgraph_from_selection(node_id) -> Dictionary:
 	var new_cloudgraph = {
 		"nodes" : {},
-		"connections" : {}
+		"edges" : {}
 		}
 	
-	var connection_keys = _g.main_graph.graph_data.connections.keys()
+	var connection_keys = _g.main_graph.graph_data.edges.keys()
 	for connection_key in connection_keys:
-		var connection = _g.main_graph.graph_data.connections[ connection_key ]
-		if [connection.from.id, connection.to.id].has(node_id) and !new_cloudgraph.connections.has(connection_key):
-			new_cloudgraph.connections[connection_key] = connection
+		var connection = _g.main_graph.graph_data.edges[ connection_key ]
+		if [connection.from.id, connection.to.id].has(node_id) and !new_cloudgraph.edges.has(connection_key):
+			new_cloudgraph.edges[connection_key] = connection
 	
 	var nodes = _g.main_graph.graph_data.nodes
-	for connection in new_cloudgraph.connections.values():
+	for connection in new_cloudgraph.edges.values():
 		var connection_id_from = connection.from.id
 		var connection_id_to = connection.to.id
 		if nodes.has(connection_id_from) and !new_cloudgraph.nodes.has(connection_id_from):
@@ -235,23 +235,23 @@ func get_cloudgraph_from_selection(node_id) -> Dictionary:
 func get_blastradius_from_selection(node_id):
 	var new_cloudgraph = {
 		"nodes" : {},
-		"connections" : {}
+		"edges" : {}
 		}
 	new_cloudgraph.nodes[node_id] = _g.main_graph.graph_data.nodes[node_id]
 	var iterations := 0
 	var all_children_resolved := false
 	var next_layer : Dictionary = new_cloudgraph.duplicate()
-	var last_layer := { "nodes" : {},"connections" : {} }
+	var last_layer := { "nodes" : {},"edges" : {} }
 	while !all_children_resolved:
 		all_children_resolved = true
-		last_layer = { "nodes" : {},"connections" : {} }
+		last_layer = { "nodes" : {},"edges" : {} }
 		
 		for node in new_cloudgraph.nodes.values():
-			var connection_keys = _g.main_graph.graph_data.connections.keys()
+			var connection_keys = _g.main_graph.graph_data.edges.keys()
 			for connection_key in connection_keys:
-				var connection = _g.main_graph.graph_data.connections[ connection_key ]
+				var connection = _g.main_graph.graph_data.edges[ connection_key ]
 				
-				if connection.from.id == node.id and !next_layer.connections.has(connection_key):
+				if connection.from.id == node.id and !next_layer.edges.has(connection_key):
 					next_layer = get_children_from_selection(node.id, next_layer)
 					
 					all_children_resolved = false
@@ -259,25 +259,26 @@ func get_blastradius_from_selection(node_id):
 		iterations += 1
 	return new_cloudgraph
 
+
 func merge_cloudgraphs(original:Dictionary, update:Dictionary) -> Dictionary:
 	for node in update.nodes.keys():
 		original.nodes[node] = update.nodes[node]
 	
-	for edge in update.connections.keys():
-		original.connections[edge] = update.connections[edge]
+	for edge in update.edges.keys():
+		original.edges[edge] = update.edges[edge]
 	
 	return original
 
 
 func get_children_from_selection(node_id, new_cloudgraph) -> Dictionary:
-	var connection_keys = _g.main_graph.graph_data.connections.keys()
+	var connection_keys = _g.main_graph.graph_data.edges.keys()
 	for connection_key in connection_keys:
-		var connection = _g.main_graph.graph_data.connections[ connection_key ]
+		var connection = _g.main_graph.graph_data.edges[ connection_key ]
 		if connection.from.id == node_id:
-			new_cloudgraph.connections[connection_key] = connection
+			new_cloudgraph.edges[connection_key] = connection
 	
 	var nodes = _g.main_graph.graph_data.nodes
-	for connection in new_cloudgraph.connections.values():
+	for connection in new_cloudgraph.edges.values():
 		var connection_id = connection.to.id
 		if nodes.has(connection_id):
 			new_cloudgraph.nodes[connection_id] = nodes[connection_id]

--- a/ckui/src/scripts/classes/class_cloud_graph.gd
+++ b/ckui/src/scripts/classes/class_cloud_graph.gd
@@ -208,23 +208,78 @@ func center_diagram():
 	$Center/Graph.position = -root_node.position# + Vector2(1920, 1080)/2
 
 
-func create_cloudgraph_from_selection(node_id) -> Dictionary:
-	var new_cloudgraph := {
-	"nodes" : {},
-	"connections" : {}
-	}
+func get_cloudgraph_from_selection(node_id) -> Dictionary:
+	var new_cloudgraph = {
+		"nodes" : {},
+		"connections" : {}
+		}
 	
 	var connection_keys = _g.main_graph.graph_data.connections.keys()
 	for connection_key in connection_keys:
-		var connection = _g.main_graph.graph_data.connections[ connection_keys ]
-		if [connection.from, connection.to].has(node_id):
-			new_cloudgraph.graph_data.connections[connection_key] = connection.duplicate()
+		var connection = _g.main_graph.graph_data.connections[ connection_key ]
+		if [connection.from.id, connection.to.id].has(node_id) and !new_cloudgraph.connections.has(connection_key):
+			new_cloudgraph.connections[connection_key] = connection
 	
 	var nodes = _g.main_graph.graph_data.nodes
-	for connection in new_cloudgraph.graph_data.connections.values():
-		if nodes.has(connection.from) and !new_cloudgraph.graph_data.nodes.has(connection.from):
-			new_cloudgraph.graph_data.nodes[connection.from] = nodes[connection.from].duplicate()
-		elif nodes.has(connection.to) and !new_cloudgraph.graph_data.nodes.has(connection.to):
-			new_cloudgraph.graph_data.nodes[connection.to] = nodes[connection.to].duplicate()
+	for connection in new_cloudgraph.connections.values():
+		var connection_id_from = connection.from.id
+		var connection_id_to = connection.to.id
+		if nodes.has(connection_id_from) and !new_cloudgraph.nodes.has(connection_id_from):
+			new_cloudgraph.nodes[connection_id_from] = nodes[connection_id_from].duplicate()
+		elif nodes.has(connection_id_to) and !new_cloudgraph.nodes.has(connection_id_to):
+			new_cloudgraph.nodes[connection_id_to] = nodes[connection_id_to].duplicate()
+
+	return new_cloudgraph
+
+
+func get_blastradius_from_selection(node_id):
+	var new_cloudgraph = {
+		"nodes" : {},
+		"connections" : {}
+		}
+	new_cloudgraph.nodes[node_id] = _g.main_graph.graph_data.nodes[node_id]
+	var iterations := 0
+	var all_children_resolved := false
+	var next_layer : Dictionary = new_cloudgraph.duplicate()
+	var last_layer := { "nodes" : {},"connections" : {} }
+	while !all_children_resolved:
+		all_children_resolved = true
+		last_layer = { "nodes" : {},"connections" : {} }
+		
+		for node in new_cloudgraph.nodes.values():
+			var connection_keys = _g.main_graph.graph_data.connections.keys()
+			for connection_key in connection_keys:
+				var connection = _g.main_graph.graph_data.connections[ connection_key ]
+				
+				if connection.from.id == node.id and !next_layer.connections.has(connection_key):
+					next_layer = get_children_from_selection(node.id, next_layer)
+					
+					all_children_resolved = false
+		new_cloudgraph = merge_cloudgraphs(new_cloudgraph, next_layer)
+		iterations += 1
+	return new_cloudgraph
+
+func merge_cloudgraphs(original:Dictionary, update:Dictionary) -> Dictionary:
+	for node in update.nodes.keys():
+		original.nodes[node] = update.nodes[node]
+	
+	for edge in update.connections.keys():
+		original.connections[edge] = update.connections[edge]
+	
+	return original
+
+
+func get_children_from_selection(node_id, new_cloudgraph) -> Dictionary:
+	var connection_keys = _g.main_graph.graph_data.connections.keys()
+	for connection_key in connection_keys:
+		var connection = _g.main_graph.graph_data.connections[ connection_key ]
+		if connection.from.id == node_id:
+			new_cloudgraph.connections[connection_key] = connection
+	
+	var nodes = _g.main_graph.graph_data.nodes
+	for connection in new_cloudgraph.connections.values():
+		var connection_id = connection.to.id
+		if nodes.has(connection_id):
+			new_cloudgraph.nodes[connection_id] = nodes[connection_id]
 	
 	return new_cloudgraph

--- a/ckui/src/scripts/classes/class_cloud_node.gd
+++ b/ckui/src/scripts/classes/class_cloud_node.gd
@@ -10,3 +10,8 @@ var from := []
 
 var velocity : Vector2
 var next_pos : Vector2
+
+func clone(original : CloudNode):
+	id = original.id
+	kind = original.kind
+	reported = original.reported.duplicate(true)

--- a/ckui/src/scripts/sfdp_test.gd
+++ b/ckui/src/scripts/sfdp_test.gd
@@ -67,18 +67,18 @@ func create_new_node(_data:Dictionary) -> CloudNode:
 	return new_cloud_node
 
 
-func add_connection(_data:Dictionary) -> CloudConnection:
-	var new_connection = CloudConnection.new()
-	new_connection.from = _g.nodes[_data.from]
-	new_connection.to = _g.nodes[_data.to]
+func add_connection(_data:Dictionary) -> CloudEdge:
+	var new_edge = CloudEdge.new()
+	new_edge.from = _g.nodes[_data.from]
+	new_edge.to = _g.nodes[_data.to]
 	
-	var new_connection_line = Line2D.new()
-	new_connection_line.width = 2
-	new_connection_line.default_color = Color(0.7,0.9,1,0.2)
-	new_connection.line = new_connection_line
-	line_group.add_child(new_connection_line)
+	var new_edge_line = Line2D.new()
+	new_edge_line.width = 2
+	new_edge_line.default_color = Color(0.7,0.9,1,0.2)
+	new_edge.line = new_edge_line
+	line_group.add_child(new_edge_line)
 	
-	return new_connection
+	return new_edge
 
 
 func update_connection_lines() -> void:

--- a/ckui/src/scripts/singletons/singleton_events.gd
+++ b/ckui/src/scripts/singletons/singleton_events.gd
@@ -2,10 +2,6 @@ extends Node
 
 signal go_to_graph_node
 signal load_query
-signal hovering_node
-signal show_node
-signal hide_nodes
-signal show_connected_nodes
 signal graph_spaceship
 signal graph_randomize
 signal graph_order

--- a/ckui/src/scripts/singletons/singleton_events.gd
+++ b/ckui/src/scripts/singletons/singleton_events.gd
@@ -11,3 +11,5 @@ signal graph_randomize
 signal graph_order
 signal nodeinfo_show
 signal nodeinfo_hide
+signal nodes_changed
+signal load_nodes

--- a/ckui/src/scripts/singletons/singleton_events.gd
+++ b/ckui/src/scripts/singletons/singleton_events.gd
@@ -13,3 +13,4 @@ signal nodeinfo_show
 signal nodeinfo_hide
 signal nodes_changed
 signal load_nodes
+signal show_blastradius

--- a/ckui/src/scripts/singletons/singleton_events.gd
+++ b/ckui/src/scripts/singletons/singleton_events.gd
@@ -9,3 +9,5 @@ signal show_connected_nodes
 signal graph_spaceship
 signal graph_randomize
 signal graph_order
+signal nodeinfo_show
+signal nodeinfo_hide

--- a/ckui/src/scripts/singletons/singleton_global.gd
+++ b/ckui/src/scripts/singletons/singleton_global.gd
@@ -3,8 +3,7 @@ extends Node
 signal nodes_changed
 signal load_nodes
 
-var nodes := {}
-var connections := {}
+var main_graph : CloudGraph setget set_main_graph
 var spaceship_mode := false
 var interface : Object = null
 var use_example_data := false
@@ -13,3 +12,16 @@ var use_example_data := false
 var queries := {
 	0 : { "short_name" : "Unused Load Balancers", "description" : "Finds unused Load Balancers in your cloud.", "query" : 'is(aws_alb) and ctime<"-{0}" and backends==[] with(empty, <-- is(aws_alb_target_group) and target_type=="instance" and ctime<"-{0}" with(empty, <-- is(aws_ec2_instance) and instance_status!="terminated")) <-[0:1]- is(aws_alb_target_group) and target_type=="instance" and ctime<"-{0}"', "dynamic_fields" : ["ctime","7d"] }
 }
+
+
+func _ready():
+	_e.connect("graph_spaceship", self, "set_spaceship_mode")
+
+
+func set_spaceship_mode():
+	spaceship_mode = !spaceship_mode
+
+
+func set_main_graph( value : CloudGraph ):
+	main_graph = value
+	emit_signal("nodes_changed")

--- a/ckui/src/scripts/singletons/singleton_global.gd
+++ b/ckui/src/scripts/singletons/singleton_global.gd
@@ -1,8 +1,5 @@
 extends Node
 
-signal nodes_changed
-signal load_nodes
-
 var main_graph : CloudGraph setget set_main_graph
 var spaceship_mode := false
 var interface : Object = null
@@ -24,4 +21,4 @@ func set_spaceship_mode():
 
 func set_main_graph( value : CloudGraph ):
 	main_graph = value
-	emit_signal("nodes_changed")
+	_e.emit_signal("nodes_changed")

--- a/ckui/src/ui/CloudkeeperUI.tscn
+++ b/ckui/src/ui/CloudkeeperUI.tscn
@@ -135,10 +135,8 @@ layer = -2
 
 [node name="BG" type="ColorRect" parent="UIGraph/BG"]
 material = SubResource( 4 )
-margin_left = -71.0
-margin_top = -73.7308
-margin_right = 1986.0
-margin_bottom = 1132.27
+margin_right = 1920.0
+margin_bottom = 1080.0
 mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
@@ -190,8 +188,8 @@ script = ExtResource( 3 )
 
 [node name="BlurTopBar" type="Sprite" parent="UI"]
 material = SubResource( 16 )
-position = Vector2( 960, 32 )
-scale = Vector2( 1920, 71 )
+position = Vector2( 960, 33.5 )
+scale = Vector2( 1920, 67 )
 z_as_relative = false
 texture = ExtResource( 2 )
 
@@ -214,12 +212,11 @@ margin_right = 1920.0
 [node name="UINodeInfo" parent="UI" instance=ExtResource( 11 )]
 
 [node name="UITopbar" parent="UI" instance=ExtResource( 8 )]
-margin_right = 1920.0
 margin_bottom = 70.0
 
 [node name="UICommandLine" parent="UI" instance=ExtResource( 1 )]
-margin_top = 1040.0
-margin_bottom = 1120.0
+margin_top = 1048.0
+margin_bottom = 1080.0
 
 [node name="Noise" type="TextureRect" parent="UI"]
 modulate = Color( 1, 1, 1, 0.0392157 )

--- a/ckui/src/ui/CloudkeeperUI.tscn
+++ b/ckui/src/ui/CloudkeeperUI.tscn
@@ -114,6 +114,7 @@ shader = SubResource( 15 )
 
 [sub_resource type="Environment" id=17]
 background_mode = 4
+background_canvas_max_layer = 10
 glow_enabled = true
 glow_levels/1 = true
 glow_levels/2 = true
@@ -238,3 +239,4 @@ environment = SubResource( 17 )
 [connection signal="input_event" from="UIGraph/BG/MouseDetector" to="UIGraph" method="_on_MouseDetector_input_event"]
 [connection signal="tween_all_completed" from="UIGraph/CamMoveTween" to="UIGraph" method="_on_CamMoveTween_tween_all_completed"]
 [connection signal="timeout" from="UIGraph/NewNodeSelectionTimer" to="UIGraph" method="_on_NewNodeSelectionTimer_timeout"]
+[connection signal="close_blast_radius" from="UI/UIBlastradius" to="." method="_on_UIBlastradius_close_blast_radius"]

--- a/ckui/src/ui/CloudkeeperUI.tscn
+++ b/ckui/src/ui/CloudkeeperUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://ui/views/UI_CommandLine.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/graphics/1px.png" type="Texture" id=2]
@@ -8,12 +8,13 @@
 [ext_resource path="res://ui/views/scripts/main_cloudkeeper_ui.gd" type="Script" id=6]
 [ext_resource path="res://ui/views/UI_Search.tscn" type="PackedScene" id=7]
 [ext_resource path="res://ui/views/UI_Topbar.tscn" type="PackedScene" id=8]
-[ext_resource path="res://ui/views/UI_GraphView.tscn" type="PackedScene" id=9]
+[ext_resource path="res://ui/elements/Element_GraphView.tscn" type="PackedScene" id=9]
+[ext_resource path="res://ui/views/scripts/ui_graph.gd" type="Script" id=10]
 [ext_resource path="res://ui/views/UI_NodeInfo.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/graphics/noise.png" type="Texture" id=12]
 [ext_resource path="res://ui/views/UI_QueryEngine.tscn" type="PackedScene" id=13]
 
-[sub_resource type="Shader" id=17]
+[sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
 
 uniform vec2 center = vec2(0.0, 0.0);
@@ -28,24 +29,24 @@ void fragment() {
 	COLOR = color;
 }"
 
-[sub_resource type="Gradient" id=18]
+[sub_resource type="Gradient" id=2]
 colors = PoolColorArray( 0.0464516, 0.144741, 0.290039, 1, 0.027451, 0.0745098, 0.168627, 1 )
 
-[sub_resource type="GradientTexture" id=19]
-gradient = SubResource( 18 )
+[sub_resource type="GradientTexture" id=3]
+gradient = SubResource( 2 )
 width = 70
 
-[sub_resource type="ShaderMaterial" id=20]
-shader = SubResource( 17 )
+[sub_resource type="ShaderMaterial" id=4]
+shader = SubResource( 1 )
 shader_param/center = Vector2( 0, 0 )
 shader_param/size = 0.5
 shader_param/squishness = Vector2( 1.5, 1 )
-shader_param/gradient = SubResource( 19 )
+shader_param/gradient = SubResource( 3 )
 
-[sub_resource type="RectangleShape2D" id=15]
+[sub_resource type="RectangleShape2D" id=5]
 extents = Vector2( 960, 540 )
 
-[sub_resource type="Shader" id=21]
+[sub_resource type="Shader" id=6]
 code = "shader_type canvas_item;
 render_mode blend_add;
 
@@ -61,33 +62,33 @@ void fragment() {
 	COLOR = color;
 }"
 
-[sub_resource type="Gradient" id=22]
+[sub_resource type="Gradient" id=7]
 colors = PoolColorArray( 0, 0.407843, 1, 0.254902, 0, 0, 0, 0 )
 
-[sub_resource type="GradientTexture" id=23]
-gradient = SubResource( 22 )
+[sub_resource type="GradientTexture" id=8]
+gradient = SubResource( 7 )
 
-[sub_resource type="ShaderMaterial" id=24]
-shader = SubResource( 21 )
+[sub_resource type="ShaderMaterial" id=9]
+shader = SubResource( 6 )
 shader_param/center = Vector2( 0, 0 )
 shader_param/size = 1.0
 shader_param/squishness = Vector2( 1, 1 )
-shader_param/gradient = SubResource( 23 )
+shader_param/gradient = SubResource( 8 )
 
-[sub_resource type="Gradient" id=25]
+[sub_resource type="Gradient" id=10]
 colors = PoolColorArray( 1, 0.294118, 0, 0.211765, 0.149902, 0, 0, 0 )
 
-[sub_resource type="GradientTexture" id=26]
-gradient = SubResource( 25 )
+[sub_resource type="GradientTexture" id=11]
+gradient = SubResource( 10 )
 
-[sub_resource type="ShaderMaterial" id=27]
-shader = SubResource( 21 )
+[sub_resource type="ShaderMaterial" id=12]
+shader = SubResource( 6 )
 shader_param/center = Vector2( 0, 0 )
 shader_param/size = 1.0
 shader_param/squishness = Vector2( 1, 1 )
-shader_param/gradient = SubResource( 26 )
+shader_param/gradient = SubResource( 11 )
 
-[sub_resource type="Shader" id=10]
+[sub_resource type="Shader" id=13]
 code = "shader_type canvas_item;
 
 uniform float power;
@@ -96,21 +97,21 @@ void fragment() {
 	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, power);
 }"
 
-[sub_resource type="ShaderMaterial" id=11]
-shader = SubResource( 10 )
+[sub_resource type="ShaderMaterial" id=14]
+shader = SubResource( 13 )
 shader_param/power = 0.0
 
-[sub_resource type="Shader" id=14]
+[sub_resource type="Shader" id=15]
 code = "shader_type canvas_item;
 
 void fragment() {
 	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, 4.0);
 }"
 
-[sub_resource type="ShaderMaterial" id=13]
-shader = SubResource( 14 )
+[sub_resource type="ShaderMaterial" id=16]
+shader = SubResource( 15 )
 
-[sub_resource type="Environment" id=16]
+[sub_resource type="Environment" id=17]
 background_mode = 4
 glow_enabled = true
 glow_levels/1 = true
@@ -122,11 +123,18 @@ glow_bicubic_upscale = true
 [node name="CloudkeeperUI" type="Node2D"]
 script = ExtResource( 6 )
 
-[node name="BG" type="CanvasLayer" parent="."]
+[node name="UIGraph" type="Node2D" parent="."]
+position = Vector2( 960, 540 )
+z_index = -1
+z_as_relative = false
+script = ExtResource( 10 )
+main_ui = NodePath("..")
+
+[node name="BG" type="CanvasLayer" parent="UIGraph"]
 layer = -2
 
-[node name="BG" type="ColorRect" parent="BG"]
-material = SubResource( 20 )
+[node name="BG" type="ColorRect" parent="UIGraph/BG"]
+material = SubResource( 4 )
 margin_left = -71.0
 margin_top = -73.7308
 margin_right = 1986.0
@@ -136,51 +144,44 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MouseDetector" type="Area2D" parent="BG"]
+[node name="MouseDetector" type="Area2D" parent="UIGraph/BG"]
 position = Vector2( 960, 540 )
 collision_mask = 0
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="BG/MouseDetector"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="UIGraph/BG/MouseDetector"]
 visible = false
-shape = SubResource( 15 )
+shape = SubResource( 5 )
 
-[node name="Graph" type="Node2D" parent="."]
-position = Vector2( 960, 540 )
-z_index = -1
-z_as_relative = false
+[node name="GraphView" parent="UIGraph" instance=ExtResource( 9 )]
 
-[node name="GraphCam" type="Camera2D" parent="Graph"]
+[node name="GraphCam" type="Camera2D" parent="UIGraph"]
 scale = Vector2( 0.1, 0.1 )
 current = true
 
-[node name="GraphView" parent="Graph" instance=ExtResource( 9 )]
-graph_cam = NodePath("../GraphCam")
-graph_bg = NodePath("../../BG/BG")
-
-[node name="Spotlight1" type="Sprite" parent="Graph"]
-material = SubResource( 24 )
+[node name="Spotlight1" type="Sprite" parent="UIGraph"]
+material = SubResource( 9 )
 position = Vector2( -1912, 1524 )
 scale = Vector2( 5.40625, 5.40625 )
 texture = ExtResource( 4 )
 
-[node name="Spotlight2" type="Sprite" parent="Graph"]
-material = SubResource( 27 )
+[node name="Spotlight2" type="Sprite" parent="UIGraph"]
+material = SubResource( 12 )
 position = Vector2( 2391.89, -991.51 )
 scale = Vector2( 3.8125, 3.8125 )
 texture = ExtResource( 4 )
 
-[node name="AnimTween" type="Tween" parent="Graph"]
+[node name="AnimTween" type="Tween" parent="UIGraph"]
 
-[node name="CamMoveTween" type="Tween" parent="Graph"]
+[node name="CamMoveTween" type="Tween" parent="UIGraph"]
 
-[node name="NewNodeSelectionTimer" type="Timer" parent="Graph"]
+[node name="NewNodeSelectionTimer" type="Timer" parent="UIGraph"]
 wait_time = 0.05
 one_shot = true
 
 [node name="UI" type="CanvasLayer" parent="."]
 
 [node name="Blur" type="Sprite" parent="UI"]
-material = SubResource( 11 )
+material = SubResource( 14 )
 position = Vector2( 960, 540 )
 scale = Vector2( 1920, 1080 )
 z_as_relative = false
@@ -188,7 +189,7 @@ texture = ExtResource( 2 )
 script = ExtResource( 3 )
 
 [node name="BlurTopBar" type="Sprite" parent="UI"]
-material = SubResource( 13 )
+material = SubResource( 16 )
 position = Vector2( 960, 32 )
 scale = Vector2( 1920, 71 )
 z_as_relative = false
@@ -232,8 +233,8 @@ __meta__ = {
 }
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource( 16 )
+environment = SubResource( 17 )
 
-[connection signal="input_event" from="BG/MouseDetector" to="." method="_on_MouseDetector_input_event"]
-[connection signal="tween_all_completed" from="Graph/CamMoveTween" to="." method="_on_CamMoveTween_tween_all_completed"]
-[connection signal="timeout" from="Graph/NewNodeSelectionTimer" to="." method="_on_NewNodeSelectionTimer_timeout"]
+[connection signal="input_event" from="UIGraph/BG/MouseDetector" to="UIGraph" method="_on_MouseDetector_input_event"]
+[connection signal="tween_all_completed" from="UIGraph/CamMoveTween" to="UIGraph" method="_on_CamMoveTween_tween_all_completed"]
+[connection signal="timeout" from="UIGraph/NewNodeSelectionTimer" to="UIGraph" method="_on_NewNodeSelectionTimer_timeout"]

--- a/ckui/src/ui/CloudkeeperUI.tscn
+++ b/ckui/src/ui/CloudkeeperUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://ui/views/UI_CommandLine.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/graphics/1px.png" type="Texture" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://ui/views/UI_NodeInfo.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/graphics/noise.png" type="Texture" id=12]
 [ext_resource path="res://ui/views/UI_QueryEngine.tscn" type="PackedScene" id=13]
+[ext_resource path="res://ui/views/UI_Blastradius.tscn" type="PackedScene" id=14]
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -210,6 +211,8 @@ margin_left = 1920.0
 margin_right = 1920.0
 
 [node name="UINodeInfo" parent="UI" instance=ExtResource( 11 )]
+
+[node name="UIBlastradius" parent="UI" instance=ExtResource( 14 )]
 
 [node name="UITopbar" parent="UI" instance=ExtResource( 8 )]
 margin_bottom = 70.0

--- a/ckui/src/ui/elements/Element_CloudNode.tscn
+++ b/ckui/src/ui/elements/Element_CloudNode.tscn
@@ -6,16 +6,16 @@
 font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
 
 [sub_resource type="DynamicFont" id=9]
-size = 56
-outline_size = 3
+size = 128
+outline_size = 4
 outline_color = Color( 0.0980392, 0.184314, 0.313726, 1 )
 use_mipmaps = true
 use_filter = true
 font_data = SubResource( 14 )
 
-[sub_resource type="DynamicFont" id=7]
-size = 32
-outline_size = 2
+[sub_resource type="DynamicFont" id=15]
+size = 64
+outline_size = 4
 outline_color = Color( 0.0980392, 0.184314, 0.313726, 1 )
 use_mipmaps = true
 use_filter = true
@@ -34,13 +34,14 @@ script = ExtResource( 1 )
 modulate = Color( 0.262745, 0.682353, 0.823529, 1 )
 polygon = PoolVector2Array( -24, 0, 0, -24, 24, 0, 0, 24 )
 
-[node name="LabelName" type="Label" parent="."]
-modulate = Color( 1, 1, 1, 0 )
-margin_left = -161.0
-margin_top = -18.0
-margin_right = 480.0
-margin_bottom = 63.0
-rect_scale = Vector2( 0.5, 0.5 )
+[node name="Labels" type="Node2D" parent="."]
+scale = Vector2( 0.3, 0.3 )
+
+[node name="LabelName" type="Label" parent="Labels"]
+margin_left = -1507.0
+margin_top = -79.0
+margin_right = 1497.0
+margin_bottom = 61.0
 custom_fonts/font = SubResource( 9 )
 text = "test"
 align = 1
@@ -48,13 +49,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LabelKind" type="Label" parent="."]
-margin_left = -91.0
-margin_top = -11.0
-margin_right = 273.0
-margin_bottom = 30.0
-rect_scale = Vector2( 0.5, 0.5 )
-custom_fonts/font = SubResource( 7 )
+[node name="LabelKind" type="Label" parent="Labels"]
+margin_left = -677.0
+margin_top = -127.0
+margin_right = 672.0
+margin_bottom = -37.0
+custom_fonts/font = SubResource( 15 )
 text = "test"
 align = 1
 valign = 1

--- a/ckui/src/ui/elements/Element_CloudNode.tscn
+++ b/ckui/src/ui/elements/Element_CloudNode.tscn
@@ -28,6 +28,7 @@ radius = 24.0
 blend_mode = 1
 
 [node name="CloudNode" type="Node2D"]
+z_index = 5
 script = ExtResource( 1 )
 
 [node name="BG" type="Polygon2D" parent="."]
@@ -63,6 +64,8 @@ __meta__ = {
 }
 
 [node name="Area2D" type="Area2D" parent="."]
+z_index = 50
+z_as_relative = false
 collision_layer = 2
 collision_mask = 0
 monitoring = false

--- a/ckui/src/ui/elements/Element_CloudNode.tscn
+++ b/ckui/src/ui/elements/Element_CloudNode.tscn
@@ -14,7 +14,7 @@ use_filter = true
 font_data = SubResource( 14 )
 
 [sub_resource type="DynamicFont" id=15]
-size = 64
+size = 90
 outline_size = 4
 outline_color = Color( 0.0980392, 0.184314, 0.313726, 1 )
 use_mipmaps = true
@@ -51,9 +51,9 @@ __meta__ = {
 
 [node name="LabelKind" type="Label" parent="Labels"]
 margin_left = -677.0
-margin_top = -127.0
+margin_top = -140.0
 margin_right = 672.0
-margin_bottom = -37.0
+margin_bottom = -42.0
 custom_fonts/font = SubResource( 15 )
 text = "test"
 align = 1

--- a/ckui/src/ui/elements/Element_GraphView.tscn
+++ b/ckui/src/ui/elements/Element_GraphView.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://ui/views/scripts/ui_graph_view.gd" type="Script" id=1]
+[ext_resource path="res://scripts/classes/class_cloud_graph.gd" type="Script" id=1]
 
 [node name="GraphView" type="Node2D"]
 z_index = -2

--- a/ckui/src/ui/elements/Element_GraphView.tscn
+++ b/ckui/src/ui/elements/Element_GraphView.tscn
@@ -6,11 +6,3 @@
 z_index = -2
 z_as_relative = false
 script = ExtResource( 1 )
-
-[node name="Center" type="Node2D" parent="."]
-
-[node name="Graph" type="Node2D" parent="Center"]
-
-[node name="LineGroup" type="Node2D" parent="Center/Graph"]
-
-[node name="NodeGroup" type="Node2D" parent="Center/Graph"]

--- a/ckui/src/ui/elements/scripts/element_cloud_node.gd
+++ b/ckui/src/ui/elements/scripts/element_cloud_node.gd
@@ -103,10 +103,10 @@ func set_node_type(value:String) -> void:
 
 
 func _on_Area2D_input_event(_viewport, event, _shape_idx) -> void:
-	if event is InputEventMouseButton and !event.pressed:
+	if event is InputEventMouseButton and !event.pressed and parent_graph.is_active:
 		# left click
 		if event.button_index == 1:
-			_e.emit_signal("go_to_graph_node", cloud_node.id)
+			_e.emit_signal("go_to_graph_node", cloud_node.id, parent_graph)
 
 		#right click
 		elif event.button_index == 2:
@@ -121,7 +121,7 @@ var speed := 15.0
 
 
 func _on_Area2D_mouse_entered():
-	if !_g.spaceship_mode:
+	if !_g.spaceship_mode and parent_graph.is_active:
 		set_hovering(true)
 
 

--- a/ckui/src/ui/elements/scripts/element_cloud_node.gd
+++ b/ckui/src/ui/elements/scripts/element_cloud_node.gd
@@ -6,6 +6,7 @@ var is_selected := false setget set_is_selected
 var cloud_node : CloudNode = null setget set_cloud_node
 var random_pos := Vector2.ZERO
 var graph_pos := Vector2.ZERO
+var parent_graph : Object = null
 
 onready var marker = $Marker
 onready var reveal = $Reveal
@@ -14,12 +15,16 @@ onready var label_kind = $Labels/LabelKind
 onready var label_name = $Labels/LabelName
 
 func _ready() -> void:
-	_e.connect("show_node", self, "show_detail")
-	_e.connect("hide_nodes", self, "hide_detail")
+	parent_graph.connect("show_node", self, "show_detail")
+	parent_graph.connect("hide_nodes", self, "hide_detail")
 	_e.connect("graph_spaceship", self, "update_spaceship_mode")
 	label_name.text = cloud_node.reported.name
 	label_kind.text = cloud_node.reported.kind
 	set_hover_power(0)
+
+
+func labels_unisize(font_scale := 0.5):
+	$Labels.global_scale = Vector2.ONE * font_scale
 
 
 func update_spaceship_mode():
@@ -28,7 +33,7 @@ func update_spaceship_mode():
 		set_hovering(false)
 		label_kind.modulate.a = 0
 		label_name.modulate.a = 0
-		label_kind.rect_position.y = -127
+		label_kind.rect_position.y = -140
 	else:
 		$Area2D.set_collision_layer_bit(1, true)
 		label_name.modulate.a = 0
@@ -129,9 +134,9 @@ func set_hovering(value:bool) -> void:
 	if hovering != value:
 		hovering = value
 		if hovering:
-			_e.emit_signal("show_connected_nodes", cloud_node.id)
+			parent_graph.emit_signal("show_connected_nodes", cloud_node.id)
 		else:
-			_e.emit_signal("hide_nodes")
+			parent_graph.emit_signal("hide_nodes")
 
 
 func set_is_selected(value:bool) -> void:
@@ -139,7 +144,7 @@ func set_is_selected(value:bool) -> void:
 	if !is_selected:
 		set_hovering(false)
 	else:
-		_e.emit_signal("show_connected_nodes", cloud_node.id)
+		parent_graph.emit_signal("show_connected_nodes", cloud_node.id)
 
 
 func set_hover_power(value:float) -> void:
@@ -149,7 +154,7 @@ func set_hover_power(value:float) -> void:
 	marker.modulate = lerp( Color.transparent, Color.white, eased_hover_power )
 	marker.width = range_lerp(eased_hover_power, 0, 1, 1, 0.5)
 	marker.rotation = eased_hover_power * PI * 0.5
-	_e.emit_signal("hovering_node", cloud_node.id, eased_hover_power)
+	parent_graph.emit_signal("hovering_node", cloud_node.id, eased_hover_power)
 
 
 func show_detail(node_id):
@@ -157,7 +162,7 @@ func show_detail(node_id):
 		return
 	reveal.remove_all()
 	reveal.interpolate_property(label_name, "modulate:a", label_name.modulate.a, 1, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
-	reveal.interpolate_property(label_kind, "rect_position:y", label_kind.rect_position.y, -127, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
+	reveal.interpolate_property(label_kind, "rect_position:y", label_kind.rect_position.y, -140, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
 	reveal.start()
 
 

--- a/ckui/src/ui/elements/scripts/element_cloud_node.gd
+++ b/ckui/src/ui/elements/scripts/element_cloud_node.gd
@@ -10,10 +10,15 @@ var graph_pos := Vector2.ZERO
 onready var marker = $Marker
 onready var reveal = $Reveal
 
+onready var label_kind = $Labels/LabelKind
+onready var label_name = $Labels/LabelName
+
 func _ready() -> void:
 	_e.connect("show_node", self, "show_detail")
 	_e.connect("hide_nodes", self, "hide_detail")
 	_e.connect("graph_spaceship", self, "update_spaceship_mode")
+	label_name.text = cloud_node.reported.name
+	label_kind.text = cloud_node.reported.kind
 	set_hover_power(0)
 
 
@@ -21,16 +26,16 @@ func update_spaceship_mode():
 	if _g.spaceship_mode:
 		is_selected = false
 		set_hovering(false)
-		$LabelKind.modulate.a = 0
-		$LabelName.modulate.a = 0
-		$LabelKind.rect_position.y = -33
+		label_kind.modulate.a = 0
+		label_name.modulate.a = 0
+		label_kind.rect_position.y = -127
 	else:
 		$Area2D.set_collision_layer_bit(1, true)
-		$LabelName.modulate.a = 0
-		$LabelKind.rect_position.y = -11
-		$LabelKind.modulate.a = 1
-		$LabelName.percent_visible = 1
-		$LabelKind.percent_visible = 1
+		label_name.modulate.a = 0
+		label_kind.rect_position.y = -52
+		label_kind.modulate.a = 1
+		label_name.percent_visible = 1
+		label_kind.percent_visible = 1
 
 
 func _process(delta) -> void:
@@ -52,22 +57,21 @@ func scanning(delta) -> void:
 	if scanned >= 2:
 		is_scanned = true
 		$Area2D.set_collision_layer_bit(1, false)
-		$LabelKind.modulate.a = 1
-		$LabelName.modulate.a = 1
+		label_kind.modulate.a = 1
+		label_name.modulate.a = 1
 		reveal.interpolate_property(self, "modulate", Color(1,2,3,1), Color.white, 1.5, Tween.TRANS_QUART, Tween.EASE_OUT)
 		reveal.start()
 	elif scanned <= 0:
-		reveal.interpolate_property($LabelKind, "modulate:a", 0, 0.5, 1, Tween.TRANS_SINE, Tween.EASE_OUT)
-		reveal.interpolate_property($LabelName, "modulate:a", 0, 0.5, 1, Tween.TRANS_SINE, Tween.EASE_OUT)
+		reveal.interpolate_property(label_kind, "modulate:a", 0, 0.5, 1, Tween.TRANS_SINE, Tween.EASE_OUT)
+		reveal.interpolate_property(label_name, "modulate:a", 0, 0.5, 1, Tween.TRANS_SINE, Tween.EASE_OUT)
 		reveal.start()
 	scanned += delta
-	$LabelName.percent_visible = clamp(scanned, 1, 2)-1
-	$LabelKind.percent_visible = clamp(scanned, 0, 1)
+	label_name.percent_visible = clamp(scanned, 1, 2)-1
+	label_kind.percent_visible = clamp(scanned, 0, 1)
+
 
 func set_cloud_node(value:CloudNode) -> void:
 	cloud_node = value
-	$LabelName.text = cloud_node.reported.name
-	$LabelKind.text = cloud_node.reported.kind
 	set_node_type(cloud_node.reported.kind)
 
 
@@ -152,13 +156,13 @@ func show_detail(node_id):
 	if node_id != cloud_node.id:
 		return
 	reveal.remove_all()
-	reveal.interpolate_property($LabelName, "modulate:a", $LabelName.modulate.a, 1, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
-	reveal.interpolate_property($LabelKind, "rect_position:y", $LabelKind.rect_position.y, -33, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
+	reveal.interpolate_property(label_name, "modulate:a", label_name.modulate.a, 1, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
+	reveal.interpolate_property(label_kind, "rect_position:y", label_kind.rect_position.y, -127, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
 	reveal.start()
 
 
 func hide_detail():
 	reveal.remove_all()
-	reveal.interpolate_property($LabelName, "modulate:a", $LabelName.modulate.a, 0, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
-	reveal.interpolate_property($LabelKind, "rect_position:y", $LabelKind.rect_position.y, -11, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
+	reveal.interpolate_property(label_name, "modulate:a", label_name.modulate.a, 0, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
+	reveal.interpolate_property(label_kind, "rect_position:y", label_kind.rect_position.y, -52, 0.1, Tween.TRANS_QUART, Tween.EASE_OUT)
 	reveal.start()

--- a/ckui/src/ui/views/UI_Blastradius.tscn
+++ b/ckui/src/ui/views/UI_Blastradius.tscn
@@ -39,7 +39,7 @@ void fragment() {
 
 [sub_resource type="Gradient" id=3]
 offsets = PoolRealArray( 0, 0.990099 )
-colors = PoolColorArray( 1, 0, 0, 0.156863, 1, 0, 0, 0.235294 )
+colors = PoolColorArray( 1, 1, 1, 0.0784314, 1, 1, 1, 0.235294 )
 
 [sub_resource type="GradientTexture" id=4]
 gradient = SubResource( 3 )
@@ -105,22 +105,39 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="StartQueryButton" parent="." instance=ExtResource( 6 )]
+[node name="CloseButton" parent="." instance=ExtResource( 6 )]
 margin_left = 1728.0
 margin_top = 96.0
 margin_right = 1856.0
 margin_bottom = 160.0
 
-[node name="ButtonLabel" parent="StartQueryButton/CenterContainer" index="0"]
+[node name="ButtonLabel" parent="CloseButton/CenterContainer" index="0"]
 margin_left = 32.0
 margin_top = 18.0
 margin_right = 96.0
 margin_bottom = 46.0
+rect_pivot_offset = Vector2( 32, 16 )
 text = "Close"
 
+[node name="BackButton" parent="." instance=ExtResource( 6 )]
+margin_left = 1584.0
+margin_top = 96.0
+margin_right = 1712.0
+margin_bottom = 160.0
+
+[node name="ButtonLabel" parent="BackButton/CenterContainer" index="0"]
+margin_left = 35.0
+margin_top = 18.0
+margin_right = 92.0
+margin_bottom = 46.0
+rect_pivot_offset = Vector2( 28, 16 )
+text = "Back"
+
 [node name="BlastUIElements" type="Node2D" parent="."]
+position = Vector2( 960, 540 )
 
 [node name="Polygon2D" type="Polygon2D" parent="BlastUIElements"]
+modulate = Color( 1, 0, 0, 1 )
 material = SubResource( 2 )
 antialiased = true
 texture = ExtResource( 3 )
@@ -142,6 +159,14 @@ __meta__ = {
 
 [node name="Instanced" type="Node2D" parent="BlastUIElements"]
 
-[connection signal="pressed" from="StartQueryButton" to="." method="_on_StartQueryButton_pressed"]
+[node name="Tween" type="Tween" parent="."]
 
-[editable path="StartQueryButton"]
+[node name="AnimTween" type="Tween" parent="."]
+
+[connection signal="pressed" from="CloseButton" to="." method="_on_CloseButton_pressed"]
+[connection signal="pressed" from="BackButton" to="." method="_on_BackButton_pressed"]
+[connection signal="tween_all_completed" from="Tween" to="." method="_on_Tween_tween_all_completed"]
+[connection signal="tween_all_completed" from="AnimTween" to="." method="_on_Tween_tween_all_completed"]
+
+[editable path="CloseButton"]
+[editable path="BackButton"]

--- a/ckui/src/ui/views/UI_Blastradius.tscn
+++ b/ckui/src/ui/views/UI_Blastradius.tscn
@@ -1,9 +1,61 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://ui/views/scripts/ui_blastradius.gd" type="Script" id=1]
-[ext_resource path="res://ui/elements/Element_GraphView.tscn" type="PackedScene" id=2]
+[ext_resource path="res://assets/graphics/1px.png" type="Texture" id=3]
+[ext_resource path="res://assets/graphics/sci-fi/small-crosses_repeat.png" type="Texture" id=4]
+[ext_resource path="res://ui/elements/Element_GenericButton.tscn" type="PackedScene" id=6]
+
+[sub_resource type="DynamicFontData" id=5]
+font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
+
+[sub_resource type="DynamicFont" id=7]
+size = 48
+font_data = SubResource( 5 )
+
+[sub_resource type="DynamicFont" id=8]
+size = 32
+font_data = SubResource( 5 )
+
+[sub_resource type="DynamicFont" id=9]
+size = 20
+font_data = SubResource( 5 )
+
+[sub_resource type="Shader" id=1]
+code = "shader_type canvas_item;
+
+uniform sampler2D gradient;
+uniform sampler2D tex;
+uniform float tex_scale;
+
+void fragment() {
+	float d = length((2.0 * (UV)) - 1.0);
+	vec2 uv = vec2(d*0.5, 0.0);
+	vec4 color = texture( gradient, uv );
+	vec4 tex_sample = texture(tex, UV*tex_scale);
+	color = mix(color, color*1.4, tex_sample);
+	
+	COLOR = color;
+}"
+
+[sub_resource type="Gradient" id=3]
+offsets = PoolRealArray( 0, 0.990099 )
+colors = PoolColorArray( 1, 0, 0, 0.156863, 1, 0, 0, 0.235294 )
+
+[sub_resource type="GradientTexture" id=4]
+gradient = SubResource( 3 )
+width = 128
+
+[sub_resource type="ShaderMaterial" id=2]
+shader = SubResource( 1 )
+shader_param/tex_scale = 10.0
+shader_param/gradient = SubResource( 4 )
+shader_param/tex = ExtResource( 4 )
+
+[sub_resource type="DynamicFont" id=6]
+font_data = SubResource( 5 )
 
 [node name="UIBlastradius" type="Control"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
@@ -12,7 +64,84 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="GraphView" parent="." instance=ExtResource( 2 )]
-position = Vector2( 960, 540 )
-z_index = 5
-z_as_relative = true
+[node name="BlastLabel" type="Label" parent="."]
+modulate = Color( 1.5, 0.3, 0.3, 1 )
+self_modulate = Color( 1, 1, 1, 0.705882 )
+margin_left = 24.0
+margin_top = 80.0
+margin_right = 235.0
+margin_bottom = 133.0
+custom_fonts/font = SubResource( 7 )
+text = "Blast Radius"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Line2D2" type="Line2D" parent="BlastLabel"]
+position = Vector2( -24, -80 )
+points = PoolVector2Array( 24, 128, 512, 128 )
+width = 2.0
+default_color = Color( 1, 1, 1, 1 )
+
+[node name="BlastNodeName" type="Label" parent="BlastLabel"]
+modulate = Color( 1, 1, 1, 0.705882 )
+margin_top = 48.0
+margin_right = 211.0
+margin_bottom = 101.0
+custom_fonts/font = SubResource( 8 )
+text = "Blast Radius"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BlastNodeInfo" type="Label" parent="BlastLabel"]
+modulate = Color( 1, 1, 1, 0.705882 )
+margin_top = 88.0
+margin_right = 211.0
+margin_bottom = 141.0
+custom_fonts/font = SubResource( 9 )
+text = "Blast Radius"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StartQueryButton" parent="." instance=ExtResource( 6 )]
+margin_left = 1728.0
+margin_top = 96.0
+margin_right = 1856.0
+margin_bottom = 160.0
+
+[node name="ButtonLabel" parent="StartQueryButton/CenterContainer" index="0"]
+margin_left = 32.0
+margin_top = 18.0
+margin_right = 96.0
+margin_bottom = 46.0
+text = "Close"
+
+[node name="BlastUIElements" type="Node2D" parent="."]
+
+[node name="Polygon2D" type="Polygon2D" parent="BlastUIElements"]
+material = SubResource( 2 )
+antialiased = true
+texture = ExtResource( 3 )
+
+[node name="Line2D" type="Line2D" parent="BlastUIElements"]
+visible = false
+width = 2.0
+default_color = Color( 2, 0.2, 0.2, 1 )
+
+[node name="Blastlevel" type="Label" parent="BlastUIElements/Line2D"]
+modulate = Color( 1.5, 0.3, 0.3, 1 )
+margin_right = 40.0
+margin_bottom = 14.0
+custom_fonts/font = SubResource( 6 )
+text = "lvl3"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Instanced" type="Node2D" parent="BlastUIElements"]
+
+[connection signal="pressed" from="StartQueryButton" to="." method="_on_StartQueryButton_pressed"]
+
+[editable path="StartQueryButton"]

--- a/ckui/src/ui/views/UI_Blastradius.tscn
+++ b/ckui/src/ui/views/UI_Blastradius.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://ui/views/scripts/ui_blastradius.gd" type="Script" id=1]
+[ext_resource path="res://ui/elements/Element_GraphView.tscn" type="PackedScene" id=2]
+
+[node name="UIBlastradius" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="GraphView" parent="." instance=ExtResource( 2 )]
+position = Vector2( 960, 540 )
+z_index = 5
+z_as_relative = true

--- a/ckui/src/ui/views/UI_CommandLine.tscn
+++ b/ckui/src/ui/views/UI_CommandLine.tscn
@@ -9,6 +9,7 @@ colors = PoolColorArray( 0.00392157, 0.105882, 0.184314, 0.823529, 0.00392157, 0
 
 [sub_resource type="GradientTexture" id=2]
 gradient = SubResource( 1 )
+width = 32
 
 [sub_resource type="CanvasItemMaterial" id=3]
 blend_mode = 1
@@ -65,27 +66,28 @@ font_data = SubResource( 10 )
 
 [node name="UICommandLine" type="Control"]
 margin_right = 1920.0
-margin_bottom = 80.0
-rect_min_size = Vector2( 1920, 80 )
+margin_bottom = 32.0
+rect_min_size = Vector2( 1920, 32 )
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Sprite" type="Sprite" parent="."]
-position = Vector2( 967.905, 44.7979 )
+position = Vector2( 960, 16 )
 rotation = 1.57079
-scale = Vector2( 0.0428915, 1951.81 )
+scale = Vector2( 1, 1920 )
 texture = SubResource( 2 )
 
 [node name="AnimTween" type="Tween" parent="."]
 
 [node name="TextureRect2" type="TextureRect" parent="."]
+modulate = Color( 0.172549, 0.513726, 0.592157, 1 )
 use_parent_material = true
 margin_left = 40.0
-margin_top = 40.0
+margin_top = 32.0
 margin_right = 80.0
-margin_bottom = 80.0
+margin_bottom = 72.0
 rect_min_size = Vector2( 40, 40 )
 rect_rotation = -180.0
 rect_scale = Vector2( 0.8, 0.8 )
@@ -97,14 +99,14 @@ __meta__ = {
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
 material = SubResource( 3 )
-position = Vector2( -24.9897, 73 )
+position = Vector2( -25, 72 )
 scale = Vector2( 1, -1 )
 color = Color( 0, 0.368627, 0.470588, 1 )
 polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
 
 [node name="Polygon2D2" type="Polygon2D" parent="."]
 material = SubResource( 3 )
-position = Vector2( 1946.01, 73 )
+position = Vector2( 1945, 72 )
 scale = Vector2( -1, -1 )
 color = Color( 0, 0.368627, 0.470588, 1 )
 polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
@@ -114,10 +116,7 @@ modulate = Color( 0.101961, 0.670588, 1, 0.121569 )
 material = SubResource( 4 )
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 0.0103149
-margin_top = -8.0
-margin_right = 0.0102539
-margin_bottom = 28.0
+margin_bottom = -8.0
 mouse_filter = 2
 texture = ExtResource( 7 )
 stretch_mode = 2
@@ -127,9 +126,9 @@ __meta__ = {
 
 [node name="Background" type="Panel" parent="."]
 margin_left = 48.0
-margin_top = 8.0
+margin_top = 4.0
 margin_right = 1816.0
-margin_bottom = 32.0
+margin_bottom = 28.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -159,9 +158,9 @@ __meta__ = {
 
 [node name="ButtonSpaceship" type="Button" parent="."]
 margin_left = 1824.0
-margin_top = 8.0
+margin_top = 4.0
 margin_right = 1848.0
-margin_bottom = 32.0
+margin_bottom = 28.0
 custom_styles/hover = SubResource( 9 )
 custom_styles/pressed = SubResource( 9 )
 custom_styles/focus = SubResource( 9 )
@@ -177,9 +176,9 @@ __meta__ = {
 
 [node name="ButtonRandomize" type="Button" parent="."]
 margin_left = 1856.0
-margin_top = 8.0
+margin_top = 4.0
 margin_right = 1880.0
-margin_bottom = 32.0
+margin_bottom = 28.0
 custom_styles/hover = SubResource( 9 )
 custom_styles/pressed = SubResource( 9 )
 custom_styles/focus = SubResource( 9 )
@@ -195,9 +194,9 @@ __meta__ = {
 
 [node name="ButtonOrder" type="Button" parent="."]
 margin_left = 1888.0
-margin_top = 8.0
+margin_top = 4.0
 margin_right = 1912.0
-margin_bottom = 32.0
+margin_bottom = 28.0
 custom_styles/hover = SubResource( 9 )
 custom_styles/pressed = SubResource( 9 )
 custom_styles/focus = SubResource( 9 )

--- a/ckui/src/ui/views/UI_CommandLine.tscn
+++ b/ckui/src/ui/views/UI_CommandLine.tscn
@@ -4,19 +4,19 @@
 [ext_resource path="res://ui/views/scripts/ui_command_line.gd" type="Script" id=2]
 [ext_resource path="res://assets/graphics/sci-fi/xsmall_pixels.png" type="Texture" id=7]
 
-[sub_resource type="Gradient" id=22]
+[sub_resource type="Gradient" id=1]
 colors = PoolColorArray( 0.00392157, 0.105882, 0.184314, 0.823529, 0.00392157, 0.105882, 0.184314, 0.823529 )
 
-[sub_resource type="GradientTexture" id=23]
-gradient = SubResource( 22 )
+[sub_resource type="GradientTexture" id=2]
+gradient = SubResource( 1 )
 
-[sub_resource type="CanvasItemMaterial" id=26]
+[sub_resource type="CanvasItemMaterial" id=3]
 blend_mode = 1
 
-[sub_resource type="CanvasItemMaterial" id=27]
+[sub_resource type="CanvasItemMaterial" id=4]
 blend_mode = 1
 
-[sub_resource type="StyleBoxFlat" id=42]
+[sub_resource type="StyleBoxFlat" id=5]
 bg_color = Color( 0.223529, 0.588235, 0.87451, 0.0509804 )
 border_width_left = 2
 border_width_top = 2
@@ -29,28 +29,20 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 corner_detail = 1
 
-[sub_resource type="DynamicFontData" id=41]
-font_path = "res://assets/fonts/SourceCodePro-Regular.ttf"
-
-[sub_resource type="DynamicFont" id=44]
-use_mipmaps = true
-use_filter = true
-extra_spacing_top = -24
-font_data = SubResource( 41 )
-
-[sub_resource type="StyleBoxEmpty" id=43]
+[sub_resource type="StyleBoxEmpty" id=6]
 content_margin_left = 8.0
 content_margin_right = 8.0
 
-[sub_resource type="DynamicFontData" id=45]
-font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
+[sub_resource type="DynamicFontData" id=7]
+font_path = "res://assets/fonts/SourceCodePro-Regular.ttf"
 
-[sub_resource type="DynamicFont" id=46]
-size = 18
-extra_spacing_top = -3
-font_data = SubResource( 45 )
+[sub_resource type="DynamicFont" id=8]
+use_mipmaps = true
+use_filter = true
+extra_spacing_top = -24
+font_data = SubResource( 7 )
 
-[sub_resource type="StyleBoxFlat" id=47]
+[sub_resource type="StyleBoxFlat" id=9]
 bg_color = Color( 0, 0, 0, 0.337255 )
 border_width_left = 2
 border_width_top = 2
@@ -62,6 +54,14 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 corner_detail = 1
+
+[sub_resource type="DynamicFontData" id=10]
+font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
+
+[sub_resource type="DynamicFont" id=11]
+size = 18
+extra_spacing_top = -3
+font_data = SubResource( 10 )
 
 [node name="UICommandLine" type="Control"]
 margin_right = 1920.0
@@ -76,7 +76,7 @@ __meta__ = {
 position = Vector2( 967.905, 44.7979 )
 rotation = 1.57079
 scale = Vector2( 0.0428915, 1951.81 )
-texture = SubResource( 23 )
+texture = SubResource( 2 )
 
 [node name="AnimTween" type="Tween" parent="."]
 
@@ -96,14 +96,14 @@ __meta__ = {
 }
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
-material = SubResource( 26 )
+material = SubResource( 3 )
 position = Vector2( -24.9897, 73 )
 scale = Vector2( 1, -1 )
 color = Color( 0, 0.368627, 0.470588, 1 )
 polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
 
 [node name="Polygon2D2" type="Polygon2D" parent="."]
-material = SubResource( 26 )
+material = SubResource( 3 )
 position = Vector2( 1946.01, 73 )
 scale = Vector2( -1, -1 )
 color = Color( 0, 0.368627, 0.470588, 1 )
@@ -111,7 +111,7 @@ polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
 
 [node name="TextureRect" type="TextureRect" parent="."]
 modulate = Color( 0.101961, 0.670588, 1, 0.121569 )
-material = SubResource( 27 )
+material = SubResource( 4 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 0.0103149
@@ -133,7 +133,7 @@ margin_bottom = 32.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 42 )
+custom_styles/panel = SubResource( 5 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -143,14 +143,14 @@ margin_right = 1848.0
 margin_bottom = 48.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+custom_styles/read_only = SubResource( 6 )
+custom_styles/focus = SubResource( 6 )
+custom_styles/normal = SubResource( 6 )
+custom_fonts/font = SubResource( 8 )
 custom_colors/selection_color = Color( 0.603922, 0.870588, 1, 0.0392157 )
 custom_colors/font_color_selected = Color( 0.603922, 0.870588, 1, 1 )
 custom_colors/font_color = Color( 1, 1, 1, 1 )
 custom_colors/clear_button_color = Color( 1, 1, 1, 1 )
-custom_fonts/font = SubResource( 44 )
-custom_styles/read_only = SubResource( 43 )
-custom_styles/focus = SubResource( 43 )
-custom_styles/normal = SubResource( 43 )
 text = "Show the current operation as a query/CLI"
 editable = false
 __meta__ = {
@@ -162,14 +162,14 @@ margin_left = 1824.0
 margin_top = 8.0
 margin_right = 1848.0
 margin_bottom = 32.0
+custom_styles/hover = SubResource( 9 )
+custom_styles/pressed = SubResource( 9 )
+custom_styles/focus = SubResource( 9 )
+custom_styles/disabled = SubResource( 9 )
+custom_styles/normal = SubResource( 9 )
+custom_fonts/font = SubResource( 11 )
 custom_colors/font_color = Color( 0.129412, 0.658824, 0.815686, 1 )
 custom_colors/font_color_hover = Color( 0.490196, 0.823529, 1, 1 )
-custom_fonts/font = SubResource( 46 )
-custom_styles/hover = SubResource( 47 )
-custom_styles/pressed = SubResource( 47 )
-custom_styles/focus = SubResource( 47 )
-custom_styles/disabled = SubResource( 47 )
-custom_styles/normal = SubResource( 47 )
 text = "S"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -180,14 +180,14 @@ margin_left = 1856.0
 margin_top = 8.0
 margin_right = 1880.0
 margin_bottom = 32.0
+custom_styles/hover = SubResource( 9 )
+custom_styles/pressed = SubResource( 9 )
+custom_styles/focus = SubResource( 9 )
+custom_styles/disabled = SubResource( 9 )
+custom_styles/normal = SubResource( 9 )
+custom_fonts/font = SubResource( 11 )
 custom_colors/font_color = Color( 0.129412, 0.658824, 0.815686, 1 )
 custom_colors/font_color_hover = Color( 0.490196, 0.823529, 1, 1 )
-custom_fonts/font = SubResource( 46 )
-custom_styles/hover = SubResource( 47 )
-custom_styles/pressed = SubResource( 47 )
-custom_styles/focus = SubResource( 47 )
-custom_styles/disabled = SubResource( 47 )
-custom_styles/normal = SubResource( 47 )
 text = "R"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -198,14 +198,14 @@ margin_left = 1888.0
 margin_top = 8.0
 margin_right = 1912.0
 margin_bottom = 32.0
+custom_styles/hover = SubResource( 9 )
+custom_styles/pressed = SubResource( 9 )
+custom_styles/focus = SubResource( 9 )
+custom_styles/disabled = SubResource( 9 )
+custom_styles/normal = SubResource( 9 )
+custom_fonts/font = SubResource( 11 )
 custom_colors/font_color = Color( 0.129412, 0.658824, 0.815686, 1 )
 custom_colors/font_color_hover = Color( 0.490196, 0.823529, 1, 1 )
-custom_fonts/font = SubResource( 46 )
-custom_styles/hover = SubResource( 47 )
-custom_styles/pressed = SubResource( 47 )
-custom_styles/focus = SubResource( 47 )
-custom_styles/disabled = SubResource( 47 )
-custom_styles/normal = SubResource( 47 )
 text = "O"
 __meta__ = {
 "_edit_use_anchors_": false

--- a/ckui/src/ui/views/UI_NodeInfo.tscn
+++ b/ckui/src/ui/views/UI_NodeInfo.tscn
@@ -8,17 +8,17 @@
 [ext_resource path="res://assets/themes/default.tres" type="Theme" id=6]
 [ext_resource path="res://assets/graphics/1px.png" type="Texture" id=7]
 
-[sub_resource type="Shader" id=40]
+[sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
 
 void fragment() {
 	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, 3.0);
 }"
 
-[sub_resource type="ShaderMaterial" id=41]
-shader = SubResource( 40 )
+[sub_resource type="ShaderMaterial" id=2]
+shader = SubResource( 1 )
 
-[sub_resource type="StyleBoxFlat" id=14]
+[sub_resource type="StyleBoxFlat" id=3]
 bg_color = Color( 0.00392157, 0.105882, 0.184314, 0.823529 )
 border_width_left = 2
 border_width_top = 2
@@ -31,13 +31,13 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 corner_detail = 1
 
-[sub_resource type="CanvasItemMaterial" id=15]
+[sub_resource type="CanvasItemMaterial" id=4]
 blend_mode = 1
 
-[sub_resource type="CanvasItemMaterial" id=16]
+[sub_resource type="CanvasItemMaterial" id=5]
 blend_mode = 1
 
-[sub_resource type="StyleBoxTexture" id=17]
+[sub_resource type="StyleBoxTexture" id=6]
 texture = ExtResource( 2 )
 region_rect = Rect2( 0, 0, 64, 64 )
 margin_left = 50.0
@@ -47,7 +47,7 @@ expand_margin_right = 5.0
 expand_margin_top = 5.0
 expand_margin_bottom = 5.0
 
-[sub_resource type="StyleBoxTexture" id=18]
+[sub_resource type="StyleBoxTexture" id=7]
 texture = ExtResource( 3 )
 region_rect = Rect2( 0, 0, 64, 64 )
 margin_right = 50.0
@@ -57,50 +57,50 @@ expand_margin_right = 5.0
 expand_margin_top = 5.0
 expand_margin_bottom = 5.0
 
-[sub_resource type="CanvasItemMaterial" id=33]
+[sub_resource type="CanvasItemMaterial" id=8]
 blend_mode = 1
 
-[sub_resource type="DynamicFontData" id=31]
+[sub_resource type="DynamicFontData" id=9]
 font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
 
-[sub_resource type="DynamicFont" id=34]
+[sub_resource type="DynamicFont" id=10]
 size = 38
 use_mipmaps = true
 use_filter = true
 extra_spacing_top = -9
 extra_spacing_char = 2
-font_data = SubResource( 31 )
+font_data = SubResource( 9 )
 
-[sub_resource type="DynamicFontData" id=32]
+[sub_resource type="DynamicFontData" id=11]
 font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
 
-[sub_resource type="DynamicFont" id=35]
+[sub_resource type="DynamicFont" id=12]
 size = 28
 use_mipmaps = true
 use_filter = true
 extra_spacing_top = -6
 extra_spacing_char = 1
-font_data = SubResource( 32 )
+font_data = SubResource( 11 )
 
-[sub_resource type="DynamicFontData" id=38]
+[sub_resource type="DynamicFontData" id=13]
 font_path = "res://assets/fonts/GemunuLibre-Bold.ttf"
 
-[sub_resource type="DynamicFont" id=6]
+[sub_resource type="DynamicFont" id=14]
 size = 30
 use_mipmaps = true
 use_filter = true
-font_data = SubResource( 38 )
+font_data = SubResource( 13 )
 
-[sub_resource type="DynamicFontData" id=36]
+[sub_resource type="DynamicFontData" id=15]
 font_path = "res://assets/fonts/GemunuLibre-Medium.ttf"
 
-[sub_resource type="DynamicFont" id=37]
+[sub_resource type="DynamicFont" id=16]
 size = 26
 use_mipmaps = true
 use_filter = true
-font_data = SubResource( 36 )
+font_data = SubResource( 15 )
 
-[sub_resource type="CanvasItemMaterial" id=39]
+[sub_resource type="CanvasItemMaterial" id=17]
 blend_mode = 1
 
 [node name="UINodeInfo" type="Control"]
@@ -110,7 +110,7 @@ __meta__ = {
 }
 
 [node name="BackgroundBlur" type="Sprite" parent="."]
-material = SubResource( 41 )
+material = SubResource( 2 )
 position = Vector2( 960, 864 )
 scale = Vector2( 1401, 323.5 )
 z_as_relative = false
@@ -125,14 +125,14 @@ rect_min_size = Vector2( 200, 200 )
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 14 )
+custom_styles/panel = SubResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="TextureRect" type="TextureRect" parent="Background"]
 modulate = Color( 0.101961, 0.670588, 1, 0.121569 )
-material = SubResource( 15 )
+material = SubResource( 4 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
@@ -144,40 +144,40 @@ __meta__ = {
 
 [node name="Extra" type="Panel" parent="Background"]
 modulate = Color( 0.372549, 0.729412, 0.92549, 1 )
-material = SubResource( 16 )
+material = SubResource( 5 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-custom_styles/panel = SubResource( 17 )
+custom_styles/panel = SubResource( 6 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Extra2" type="Panel" parent="Background"]
 modulate = Color( 0.372549, 0.729412, 0.92549, 1 )
-material = SubResource( 16 )
+material = SubResource( 5 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-custom_styles/panel = SubResource( 18 )
+custom_styles/panel = SubResource( 7 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="NodeNameLabel" type="Label" parent="Background"]
-material = SubResource( 33 )
+material = SubResource( 8 )
 margin_left = 17.0
 margin_top = 16.0
 margin_right = 243.0
 margin_bottom = 71.0
 rect_min_size = Vector2( 0, 55 )
 mouse_filter = 1
+custom_fonts/font = SubResource( 10 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 10
 custom_constants/shadow_as_outline = 1
-custom_fonts/font = SubResource( 34 )
 text = "Total Instances"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -190,11 +190,11 @@ margin_top = 30.2906
 margin_right = 225.0
 margin_bottom = 67.2906
 mouse_filter = 1
+custom_fonts/font = SubResource( 12 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_y = 5
 custom_constants/shadow_as_outline = 1
-custom_fonts/font = SubResource( 35 )
 text = "Date range"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -208,9 +208,9 @@ margin_top = 80.0
 margin_right = -400.0
 margin_bottom = -32.0
 theme = ExtResource( 6 )
+custom_fonts/bold_font = SubResource( 14 )
+custom_fonts/normal_font = SubResource( 16 )
 custom_colors/default_color = Color( 0.517647, 0.901961, 1, 1 )
-custom_fonts/bold_font = SubResource( 6 )
-custom_fonts/normal_font = SubResource( 37 )
 bbcode_enabled = true
 bbcode_text = "Info
 Info
@@ -285,7 +285,7 @@ margin_bottom = 30.0
 text = "Manage tags"
 
 [node name="Line2D" type="Line2D" parent="Background"]
-material = SubResource( 39 )
+material = SubResource( 17 )
 points = PoolVector2Array( 1025, 32, 1025, 288 )
 width = 2.0
 default_color = Color( 0.517647, 0.901961, 1, 0.32549 )

--- a/ckui/src/ui/views/UI_NodeInfo.tscn
+++ b/ckui/src/ui/views/UI_NodeInfo.tscn
@@ -172,12 +172,12 @@ margin_right = 243.0
 margin_bottom = 71.0
 rect_min_size = Vector2( 0, 55 )
 mouse_filter = 1
-custom_fonts/font = SubResource( 10 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 10
 custom_constants/shadow_as_outline = 1
+custom_fonts/font = SubResource( 10 )
 text = "Total Instances"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -190,11 +190,11 @@ margin_top = 30.2906
 margin_right = 225.0
 margin_bottom = 67.2906
 mouse_filter = 1
-custom_fonts/font = SubResource( 12 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_y = 5
 custom_constants/shadow_as_outline = 1
+custom_fonts/font = SubResource( 12 )
 text = "Date range"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -208,9 +208,9 @@ margin_top = 80.0
 margin_right = -400.0
 margin_bottom = -32.0
 theme = ExtResource( 6 )
+custom_colors/default_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_fonts/bold_font = SubResource( 14 )
 custom_fonts/normal_font = SubResource( 16 )
-custom_colors/default_color = Color( 0.517647, 0.901961, 1, 1 )
 bbcode_enabled = true
 bbcode_text = "Info
 Info
@@ -292,6 +292,7 @@ default_color = Color( 0.517647, 0.901961, 1, 0.32549 )
 
 [node name="AnimTween" type="Tween" parent="."]
 
+[connection signal="pressed" from="Background/MarkForCleanupButton" to="." method="_on_MarkForCleanupButton_pressed"]
 [connection signal="tween_all_completed" from="AnimTween" to="." method="_on_AnimTween_tween_all_completed"]
 
 [editable path="Background/ContactOwnerButton"]

--- a/ckui/src/ui/views/UI_Search.tscn
+++ b/ckui/src/ui/views/UI_Search.tscn
@@ -7,7 +7,7 @@
 [ext_resource path="res://assets/graphics/sci-fi/extra_border2.png" type="Texture" id=5]
 [ext_resource path="res://assets/graphics/sci-fi/xsmall_pixels.png" type="Texture" id=6]
 
-[sub_resource type="StyleBoxFlat" id=28]
+[sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.223529, 0.588235, 0.87451, 0.0509804 )
 border_width_left = 2
 border_width_top = 2
@@ -20,35 +20,35 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 corner_detail = 1
 
-[sub_resource type="DynamicFontData" id=33]
+[sub_resource type="StyleBoxEmpty" id=2]
+
+[sub_resource type="StyleBoxEmpty" id=3]
+
+[sub_resource type="DynamicFontData" id=4]
 font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
 
-[sub_resource type="DynamicFont" id=34]
+[sub_resource type="DynamicFont" id=5]
 size = 160
 use_mipmaps = true
 use_filter = true
 extra_spacing_top = -20
-font_data = SubResource( 33 )
+font_data = SubResource( 4 )
 
-[sub_resource type="StyleBoxEmpty" id=18]
-
-[sub_resource type="StyleBoxEmpty" id=19]
-
-[sub_resource type="CanvasItemMaterial" id=36]
+[sub_resource type="CanvasItemMaterial" id=6]
 blend_mode = 1
 
-[sub_resource type="DynamicFontData" id=41]
+[sub_resource type="DynamicFontData" id=7]
 font_path = "res://assets/fonts/GemunuLibre-Light.ttf"
 
-[sub_resource type="DynamicFont" id=38]
+[sub_resource type="DynamicFont" id=8]
 size = 38
 use_mipmaps = true
 use_filter = true
 extra_spacing_top = -9
 extra_spacing_char = 2
-font_data = SubResource( 41 )
+font_data = SubResource( 7 )
 
-[sub_resource type="Shader" id=13]
+[sub_resource type="Shader" id=9]
 code = "shader_type canvas_item;
 render_mode blend_add;
 
@@ -57,10 +57,10 @@ void fragment() {
 	COLOR.a = abs((0.8 - UV.y)*1.5);
 }"
 
-[sub_resource type="ShaderMaterial" id=15]
-shader = SubResource( 13 )
+[sub_resource type="ShaderMaterial" id=10]
+shader = SubResource( 9 )
 
-[sub_resource type="StyleBoxFlat" id=39]
+[sub_resource type="StyleBoxFlat" id=11]
 bg_color = Color( 1, 1, 1, 0.0392157 )
 border_width_left = 2
 border_width_top = 2
@@ -72,13 +72,13 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 corner_detail = 1
 
-[sub_resource type="CanvasItemMaterial" id=29]
+[sub_resource type="CanvasItemMaterial" id=12]
 blend_mode = 1
 
-[sub_resource type="CanvasItemMaterial" id=30]
+[sub_resource type="CanvasItemMaterial" id=13]
 blend_mode = 1
 
-[sub_resource type="StyleBoxTexture" id=31]
+[sub_resource type="StyleBoxTexture" id=14]
 texture = ExtResource( 4 )
 region_rect = Rect2( 0, 0, 64, 64 )
 margin_left = 50.0
@@ -88,7 +88,7 @@ expand_margin_right = 5.0
 expand_margin_top = 5.0
 expand_margin_bottom = 5.0
 
-[sub_resource type="StyleBoxTexture" id=32]
+[sub_resource type="StyleBoxTexture" id=15]
 texture = ExtResource( 5 )
 region_rect = Rect2( 0, 0, 64, 64 )
 margin_right = 50.0
@@ -98,16 +98,16 @@ expand_margin_right = 5.0
 expand_margin_top = 5.0
 expand_margin_bottom = 5.0
 
-[sub_resource type="StyleBoxEmpty" id=22]
+[sub_resource type="StyleBoxEmpty" id=16]
 
-[sub_resource type="DynamicFontData" id=40]
+[sub_resource type="DynamicFontData" id=17]
 font_path = "res://assets/fonts/Lato-Regular.ttf"
 
-[sub_resource type="DynamicFont" id=26]
+[sub_resource type="DynamicFont" id=18]
 size = 26
 use_mipmaps = true
 use_filter = true
-font_data = SubResource( 40 )
+font_data = SubResource( 17 )
 
 [node name="UISearch" type="Control"]
 anchor_right = 1.0
@@ -137,7 +137,7 @@ margin_bottom = 440.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 28 )
+custom_styles/panel = SubResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -159,30 +159,30 @@ margin_left = 20.0
 margin_top = 20.0
 margin_right = 1700.0
 margin_bottom = 220.0
+custom_icons/clear = ExtResource( 1 )
+custom_styles/focus = SubResource( 2 )
+custom_styles/normal = SubResource( 3 )
+custom_fonts/font = SubResource( 5 )
 custom_colors/selection_color = Color( 0.603922, 0.870588, 1, 0.0392157 )
 custom_colors/font_color_selected = Color( 0.603922, 0.870588, 1, 1 )
 custom_colors/font_color = Color( 1, 1, 1, 1 )
 custom_colors/clear_button_color = Color( 1, 1, 1, 1 )
-custom_fonts/font = SubResource( 34 )
-custom_icons/clear = ExtResource( 1 )
-custom_styles/focus = SubResource( 18 )
-custom_styles/normal = SubResource( 19 )
 text = "test"
 clear_button_enabled = true
 
 [node name="SearchLabel" type="Label" parent="SearchContainer/Background"]
-material = SubResource( 36 )
+material = SubResource( 6 )
 margin_top = -43.0
 margin_right = 1720.0
 margin_bottom = 12.0
 rect_min_size = Vector2( 0, 55 )
 mouse_filter = 1
+custom_fonts/font = SubResource( 8 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 10
 custom_constants/shadow_as_outline = 1
-custom_fonts/font = SubResource( 38 )
 text = "Search in Cloudkeeper"
 align = 1
 __meta__ = {
@@ -191,20 +191,20 @@ __meta__ = {
 
 [node name="BackgroundShader" type="Panel" parent="SearchContainer/Background"]
 modulate = Color( 0.176471, 0.827451, 1, 0.129412 )
-material = SubResource( 15 )
+material = SubResource( 10 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 39 )
+custom_styles/panel = SubResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": true
 }
 
 [node name="TextureRect" type="TextureRect" parent="SearchContainer/Background"]
 modulate = Color( 0.101961, 0.670588, 1, 0.121569 )
-material = SubResource( 29 )
+material = SubResource( 12 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
@@ -216,22 +216,22 @@ __meta__ = {
 
 [node name="Extra" type="Panel" parent="SearchContainer/Background"]
 modulate = Color( 0.372549, 0.729412, 0.92549, 1 )
-material = SubResource( 30 )
+material = SubResource( 13 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-custom_styles/panel = SubResource( 31 )
+custom_styles/panel = SubResource( 14 )
 __meta__ = {
 "_edit_use_anchors_": true
 }
 
 [node name="Extra2" type="Panel" parent="SearchContainer/Background"]
 modulate = Color( 0.372549, 0.729412, 0.92549, 1 )
-material = SubResource( 30 )
+material = SubResource( 13 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-custom_styles/panel = SubResource( 32 )
+custom_styles/panel = SubResource( 15 )
 __meta__ = {
 "_edit_use_anchors_": true
 }
@@ -258,7 +258,7 @@ margin_bottom = 560.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 22 )
+custom_styles/panel = SubResource( 16 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -305,7 +305,7 @@ margin_bottom = 36.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 3
 theme = ExtResource( 3 )
-custom_fonts/font = SubResource( 26 )
+custom_fonts/font = SubResource( 18 )
 text = "Queries"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -318,7 +318,7 @@ margin_right = 495.0
 margin_bottom = 36.0
 size_flags_horizontal = 3
 theme = ExtResource( 3 )
-custom_fonts/font = SubResource( 26 )
+custom_fonts/font = SubResource( 18 )
 text = "Queries"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -339,16 +339,16 @@ __meta__ = {
 }
 
 [node name="QueriesLabel" type="Label" parent="ResultContainer/Results/HBoxContainer/QueryResults"]
-material = SubResource( 36 )
+material = SubResource( 6 )
 margin_right = 1720.0
 margin_bottom = 55.0
 rect_min_size = Vector2( 0, 55 )
 mouse_filter = 1
+custom_fonts/font = SubResource( 8 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_y = 10
 custom_constants/shadow_as_outline = 1
-custom_fonts/font = SubResource( 38 )
 text = "Queries"
 align = 1
 __meta__ = {
@@ -367,17 +367,17 @@ margin_bottom = 168.0
 size_flags_horizontal = 3
 
 [node name="NodesLabel" type="Label" parent="ResultContainer/Results/HBoxContainer/CloudResults"]
-material = SubResource( 36 )
+material = SubResource( 6 )
 margin_right = 1720.0
 margin_bottom = 55.0
 rect_min_size = Vector2( 0, 55 )
 mouse_filter = 1
+custom_fonts/font = SubResource( 8 )
 custom_colors/font_color = Color( 0.517647, 0.901961, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0.843137, 1, 0.0392157 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 10
 custom_constants/shadow_as_outline = 1
-custom_fonts/font = SubResource( 38 )
 text = "Cloud Resources"
 align = 1
 __meta__ = {

--- a/ckui/src/ui/views/UI_Topbar.tscn
+++ b/ckui/src/ui/views/UI_Topbar.tscn
@@ -8,41 +8,42 @@
 [ext_resource path="res://assets/graphics/icons/icon_nodes.png" type="Texture" id=6]
 [ext_resource path="res://assets/graphics/sci-fi/xsmall_pixels.png" type="Texture" id=7]
 
-[sub_resource type="Gradient" id=22]
+[sub_resource type="Gradient" id=1]
 colors = PoolColorArray( 0.00392157, 0.105882, 0.184314, 0.823529, 0.00392157, 0.105882, 0.184314, 0.823529 )
 
-[sub_resource type="GradientTexture" id=23]
-gradient = SubResource( 22 )
+[sub_resource type="GradientTexture" id=2]
+gradient = SubResource( 1 )
+width = 65
 
-[sub_resource type="DynamicFontData" id=24]
+[sub_resource type="DynamicFontData" id=3]
 font_path = "res://assets/fonts/GemunuLibre-VariableFont_wght.ttf"
 
-[sub_resource type="DynamicFont" id=25]
+[sub_resource type="DynamicFont" id=4]
 size = 38
 use_mipmaps = true
 use_filter = true
-font_data = SubResource( 24 )
+font_data = SubResource( 3 )
 
-[sub_resource type="CanvasItemMaterial" id=26]
+[sub_resource type="CanvasItemMaterial" id=5]
 blend_mode = 1
 
-[sub_resource type="CanvasItemMaterial" id=27]
+[sub_resource type="CanvasItemMaterial" id=6]
 blend_mode = 1
 
 [node name="UITopbar" type="Control"]
-margin_right = 40.0
-margin_bottom = 40.0
-rect_min_size = Vector2( 1920, 70 )
+margin_right = 1920.0
+margin_bottom = 66.0
+rect_min_size = Vector2( 1920, 66 )
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Sprite" type="Sprite" parent="."]
-position = Vector2( 967.895, 22.7977 )
+position = Vector2( 960, 32.5 )
 rotation = 1.57079
-scale = Vector2( 0.0428915, 1951.81 )
-texture = SubResource( 23 )
+scale = Vector2( 1, 1920 )
+texture = SubResource( 2 )
 
 [node name="UserIcon" type="Sprite" parent="."]
 modulate = Color( 0.603922, 0.905882, 1, 1 )
@@ -58,8 +59,8 @@ margin_left = 1400.0
 margin_top = 2.0
 margin_right = 1856.0
 margin_bottom = 54.0
-custom_fonts/font = SubResource( 25 )
-text = "Lars Kamp"
+custom_fonts/font = SubResource( 4 )
+text = "Some Engineer"
 align = 2
 valign = 1
 __meta__ = {
@@ -133,25 +134,23 @@ texture = ExtResource( 4 )
 text = "Query "
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
-material = SubResource( 26 )
-position = Vector2( -25, -5 )
+material = SubResource( 5 )
+position = Vector2( -25, -6 )
 color = Color( 0, 0.368627, 0.470588, 1 )
 polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
 
 [node name="Polygon2D2" type="Polygon2D" parent="."]
-material = SubResource( 26 )
-position = Vector2( 1946, -5 )
+material = SubResource( 5 )
+position = Vector2( 1946, -6 )
 scale = Vector2( -1, 1 )
 color = Color( 0, 0.368627, 0.470588, 1 )
 polygon = PoolVector2Array( 25, 70, 25, 73, 151, 73, 151, 72, 48, 72, 48, 70 )
 
 [node name="TextureRect" type="TextureRect" parent="."]
 modulate = Color( 0.101961, 0.670588, 1, 0.121569 )
-material = SubResource( 27 )
+material = SubResource( 6 )
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_top = -30.0
-margin_bottom = 6.0
 mouse_filter = 2
 texture = ExtResource( 7 )
 stretch_mode = 2

--- a/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
+++ b/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
@@ -8,6 +8,7 @@ onready var ui_dashboard = $UI/UIDashboard
 onready var ui_query = $UI/UIQueryEngine
 onready var ui_topbar = $UI/UITopbar
 onready var ui_search = $UI/UISearch
+onready var ui_blastradius = $UI/UIBlastradius
 
 
 var state = -1 setget set_state
@@ -84,8 +85,12 @@ func hide_interface(state_id:int) -> void:
 		_e.emit_signal("nodeinfo_hide")
 		var ui_tween = ui_graph.get_node("AnimTween")
 		ui_graph.zoom_out()
+		ui_graph.is_active = false
 		ui_tween.interpolate_method(blur, "set_blur", blur.blur_power, 1, 0.7, Tween.TRANS_QUAD, Tween.EASE_OUT)
 		ui_tween.start()
+		
+	elif state_id == states.BLASTRADIUS:
+		ui_blastradius.hide()
 
 
 func show_interface(state_id:int) -> void:
@@ -110,9 +115,13 @@ func show_interface(state_id:int) -> void:
 		
 	elif state_id == states.GRAPH:
 		var ui_tween = ui_graph.get_node("AnimTween")
+		ui_graph.is_active = true
 		ui_graph.zoom_in()
 		ui_tween.interpolate_method(blur, "set_blur", blur.blur_power, 0, 0.7, Tween.TRANS_QUAD, Tween.EASE_OUT)
 		ui_tween.start()
+	
+	elif state_id == states.BLASTRADIUS:
+		ui_blastradius.show()
 
 
 func show_blastradius(_id) -> void:
@@ -128,4 +137,8 @@ func load_query(_query_id) -> void:
 
 
 func update_spaceship_mode():
-	state = states.GRAPH
+	set_state(states.GRAPH)
+
+
+func _on_UIBlastradius_close_blast_radius():
+	set_state(states.GRAPH)

--- a/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
+++ b/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
@@ -3,68 +3,29 @@ extends Node2D
 enum states {GRAPH, SEARCH, DASHBOARD, QUERY}
 
 onready var blur = $UI/Blur
-onready var ui_graph = $Graph
-onready var graph_cam = $Graph/GraphCam
+onready var ui_graph = $UIGraph
 onready var ui_dashboard = $UI/UIDashboard
 onready var ui_query = $UI/UIQueryEngine
-onready var ui_nodeinfo = $UI/UINodeInfo
 onready var ui_topbar = $UI/UITopbar
 onready var ui_search = $UI/UISearch
-onready var cam_tween = $Graph/CamMoveTween
+
 
 var state = -1 setget set_state
 var old_state = -1
-var cam_moving := false
-var selected_new_node := false
-var target_node : CloudNode = null
-var mouse_is_pressed := false
-var last_drag_pos := Vector2.ZERO
-var new_drag_pos := Vector2.ZERO
-var is_dragging_cam := false
-var drag_sensitivity := 1.0
-var drag_power := Vector2.ZERO
-var spaceship : Object = null
-var Spaceship = preload("res://ui/elements/Element_Spaceship.tscn")
+
 
 func _ready() -> void:
 	_g.interface = self
 	_g.emit_signal("load_nodes")
 	_e.connect("go_to_graph_node", self, "go_to_graph_node")
+	_e.connect("graph_spaceship", self, "update_spaceship_mode")
 	_e.connect("load_query", self, "load_query")
-	_e.connect("graph_spaceship", self, "set_spaceship_mode")
+	
 	ui_dashboard.show()
 	ui_dashboard.rect_global_position = Vector2(-1920,0)
 	ui_query.show()
-	graph_cam.zoom = Vector2.ONE*0.8
 	ui_search.modulate.a = 0
-	graph_cam.global_position = _g.nodes[ _g.nodes.keys()[1] ].icon.global_position
 	set_state(states.GRAPH)
-
-
-func _physics_process(delta):
-	mouse_is_pressed = Input.is_action_pressed("left_mouse")
-	if mouse_is_pressed and !target_node and !selected_new_node and state == states.GRAPH and !_g.spaceship_mode:
-		if !is_dragging_cam:
-			is_dragging_cam = true
-			new_drag_pos = get_viewport().get_mouse_position()
-			last_drag_pos = new_drag_pos
-		else:
-			new_drag_pos = get_viewport().get_mouse_position()
-			drag_power = (new_drag_pos-last_drag_pos)
-			last_drag_pos = new_drag_pos
-	else:
-		drag_power *= 50*delta
-		is_dragging_cam = false
-	graph_cam.position -= drag_power*graph_cam.zoom.x
-	
-	if state == states.GRAPH:
-		if Input.is_action_just_released("zoom_in"):
-			graph_cam.zoom = max(graph_cam.zoom.x * 0.95, 0.2) * Vector2.ONE
-		elif Input.is_action_just_released("zoom_out"):
-			graph_cam.zoom = min(graph_cam.zoom.x * 1.05, 4) * Vector2.ONE
-	
-	if _g.spaceship_mode:
-		graph_cam.global_position = spaceship.global_position
 
 
 func _input(event) -> void:
@@ -87,7 +48,7 @@ func _input(event) -> void:
 
 
 func set_state(new_state:int) -> void:
-	if new_state == state:
+	if new_state == state or _g.spaceship_mode:
 		return
 	
 	old_state = state
@@ -119,9 +80,9 @@ func hide_interface(state_id:int) -> void:
 		ui_tween.start()
 		
 	elif state_id == states.GRAPH:
-		ui_nodeinfo.hide_info()
+		_e.emit_signal("nodeinfo_hide")
 		var ui_tween = ui_graph.get_node("AnimTween")
-		ui_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE*0.4, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
+		ui_graph.zoom_out()
 		ui_tween.interpolate_method(blur, "set_blur", blur.blur_power, 1, 0.7, Tween.TRANS_QUAD, Tween.EASE_OUT)
 		ui_tween.start()
 
@@ -148,71 +109,17 @@ func show_interface(state_id:int) -> void:
 		
 	elif state_id == states.GRAPH:
 		var ui_tween = ui_graph.get_node("AnimTween")
-		ui_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE*0.8, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
+		ui_graph.zoom_in()
 		ui_tween.interpolate_method(blur, "set_blur", blur.blur_power, 0, 0.7, Tween.TRANS_QUAD, Tween.EASE_OUT)
 		ui_tween.start()
 
 
 func go_to_graph_node(node_id) -> void:
-	if target_node != null:
-		target_node.icon.is_selected = false
-	
 	set_state(states.GRAPH)
-	ui_nodeinfo.hide_info()
-	target_node = _g.nodes[node_id]
-	_e.emit_signal("hide_nodes")
-	_e.emit_signal("show_node", node_id)
-	
-	selected_new_node = true
-	$Graph/NewNodeSelectionTimer.start()
-	var target_pos = target_node.icon.global_position
-	var target_zoom = target_node.icon.scale
-	var flytime = range_lerp(clamp(target_pos.distance_to(graph_cam.global_position), 100, 1000), 100, 1000, 0.35, 1.5)
-	cam_tween.interpolate_property(graph_cam, "global_position", graph_cam.global_position, target_pos, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
-	cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, target_zoom*0.5, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
-	cam_tween.start()
-	target_node.icon.is_selected = true
-	cam_moving = true
-
 
 func load_query(_query_id) -> void:
 	set_state(states.QUERY)
 
 
-func _on_CamMoveTween_tween_all_completed() -> void:
-	if target_node != null and cam_moving:
-		cam_moving = false
-		ui_nodeinfo.show_info(target_node)
-
-
-func _on_MouseDetector_input_event(_viewport, event, _shape_idx):
-	if event is InputEventMouseButton:
-		if !event.pressed and !selected_new_node and target_node != null:
-			cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE*0.8, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
-			cam_tween.start()
-			target_node.icon.is_selected = false
-			target_node = null
-			cam_moving = false
-			ui_nodeinfo.hide_info()
-
-
-func _on_NewNodeSelectionTimer_timeout():
-	selected_new_node = false
-
-
-func set_spaceship_mode():
-	_g.spaceship_mode = !_g.spaceship_mode
-	if _g.spaceship_mode:
-		spaceship = Spaceship.instance()
-		$Graph.add_child(spaceship)
-		spaceship.global_position = graph_cam.global_position
-		spaceship.appear()
-		cam_tween.remove_all()
-		cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2(0.2,0.2), 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
-		cam_tween.start()
-	else:
-		cam_tween.remove_all()
-		cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE, 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
-		cam_tween.start()
-		spaceship.vanish()
-		spaceship = null
+func update_spaceship_mode():
+	state = states.GRAPH

--- a/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
+++ b/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
@@ -16,7 +16,7 @@ var old_state = -1
 
 func _ready() -> void:
 	_g.interface = self
-	_g.emit_signal("load_nodes")
+	_e.emit_signal("load_nodes")
 	_e.connect("go_to_graph_node", self, "go_to_graph_node")
 	_e.connect("graph_spaceship", self, "update_spaceship_mode")
 	_e.connect("load_query", self, "load_query")
@@ -114,7 +114,7 @@ func show_interface(state_id:int) -> void:
 		ui_tween.start()
 
 
-func go_to_graph_node(node_id) -> void:
+func go_to_graph_node(_node_id) -> void:
 	set_state(states.GRAPH)
 
 func load_query(_query_id) -> void:

--- a/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
+++ b/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
@@ -90,6 +90,12 @@ func hide_interface(state_id:int) -> void:
 		ui_tween.start()
 		
 	elif state_id == states.BLASTRADIUS:
+		ui_blastradius.clear_blastradius()
+		ui_blastradius.clear_history()
+		var ui_tween = ui_blastradius.get_node("AnimTween")
+		ui_tween.interpolate_property(ui_blastradius, "modulate:a", ui_blastradius.modulate.a, 0, 0.3, Tween.TRANS_EXPO, Tween.EASE_OUT)
+		ui_tween.start()
+		yield(ui_tween, "tween_all_completed")
 		ui_blastradius.hide()
 
 
@@ -122,13 +128,18 @@ func show_interface(state_id:int) -> void:
 	
 	elif state_id == states.BLASTRADIUS:
 		ui_blastradius.show()
+		var ui_tween = ui_blastradius.get_node("AnimTween")
+		ui_tween.interpolate_property(ui_blastradius, "modulate:a", ui_blastradius.modulate.a, 1, 0.1, Tween.TRANS_EXPO, Tween.EASE_OUT)
+		ui_tween.start()
 
 
 func show_blastradius(_id) -> void:
 	set_state(states.BLASTRADIUS)
 
 
-func go_to_graph_node(_node_id) -> void:
+func go_to_graph_node(_node_id, graph) -> void:
+	if graph != _g.main_graph:
+		return
 	set_state(states.GRAPH)
 
 

--- a/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
+++ b/ckui/src/ui/views/scripts/main_cloudkeeper_ui.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-enum states {GRAPH, SEARCH, DASHBOARD, QUERY}
+enum states {GRAPH, SEARCH, DASHBOARD, QUERY, BLASTRADIUS}
 
 onready var blur = $UI/Blur
 onready var ui_graph = $UIGraph
@@ -20,6 +20,7 @@ func _ready() -> void:
 	_e.connect("go_to_graph_node", self, "go_to_graph_node")
 	_e.connect("graph_spaceship", self, "update_spaceship_mode")
 	_e.connect("load_query", self, "load_query")
+	_e.connect("show_blastradius", self, "show_blastradius")
 	
 	ui_dashboard.show()
 	ui_dashboard.rect_global_position = Vector2(-1920,0)
@@ -114,8 +115,13 @@ func show_interface(state_id:int) -> void:
 		ui_tween.start()
 
 
+func show_blastradius(_id) -> void:
+	set_state(states.BLASTRADIUS)
+
+
 func go_to_graph_node(_node_id) -> void:
 	set_state(states.GRAPH)
+
 
 func load_query(_query_id) -> void:
 	set_state(states.QUERY)

--- a/ckui/src/ui/views/scripts/ui_blastradius.gd
+++ b/ckui/src/ui/views/scripts/ui_blastradius.gd
@@ -1,0 +1,99 @@
+extends Control
+
+var node_distance := {}
+
+onready var graph_view = $GraphView
+
+func _ready():
+	_e.connect("show_blastradius", self, "show_blastradius")
+	_e.disconnect("hovering_node", graph_view, "hovering_node")
+	_e.disconnect("show_connected_nodes", graph_view, "show_connected_nodes")
+
+
+func show_blastradius(node_id):
+	var blastradius = get_blastradius_from_selection(node_id)
+	graph_view.create_graph_direct(blastradius)
+	graph_view.graph_rand_layout()
+	graph_view.graph_calc_layout()
+	graph_view.update_connection_lines()
+	for node in graph_view.graph_data.nodes.values():
+		node.icon.show_detail(node.id)
+
+
+func get_blastradius_from_selection(node_id):
+	node_distance.clear()
+	var new_cloudgraph = {
+		"nodes" : {},
+		"edges" : {}
+		}
+	new_cloudgraph.nodes[node_id] = _g.main_graph.graph_data.nodes[node_id]
+	var iterations := 0
+	var all_children_resolved := false
+	var next_layer : Dictionary = new_cloudgraph.duplicate()
+	var current_layer : Dictionary = {}
+	current_layer["nodes"] = []
+	
+	while !all_children_resolved:
+		all_children_resolved = true
+		current_layer["nodes"].clear()
+		current_layer["nodes"] = next_layer.nodes.duplicate()
+		
+		for node in next_layer.nodes.values():
+			# set the node distance from center
+			node_distance[node.id] = iterations
+			var edge_keys = _g.main_graph.graph_data.edges.keys()
+			for edge_key in edge_keys:
+				var connection = _g.main_graph.graph_data.edges[ edge_key ]
+				if connection.from.id == node.id and !next_layer.edges.has(edge_key):
+					next_layer = get_children_from_selection(node.id, next_layer)
+					all_children_resolved = false
+		
+		new_cloudgraph = merge_cloudgraphs(new_cloudgraph, next_layer, iterations)
+		next_layer = clean_duplicate_nodes(next_layer, current_layer)
+		iterations += 1
+
+	return new_cloudgraph
+
+
+func merge_cloudgraphs(original:Dictionary, update:Dictionary, iterations:int) -> Dictionary:
+	for node in update.nodes.keys():
+		if !original.nodes.has(node):
+			original.nodes[node] = update.nodes[node]
+			node_distance[node] = iterations
+	
+	for edge in update.edges.keys():
+		if !original.edges.has(edge):
+			original.edges[edge] = update.edges[edge]
+	
+	original["nodes"] = original["nodes"].duplicate()
+	original["edges"] = original["edges"].duplicate()
+	return original
+
+
+func clean_duplicate_nodes(original:Dictionary, update:Dictionary) -> Dictionary:
+	for node in update.nodes.keys():
+		original.nodes.erase(node)
+	
+		var edge_keys = original.edges.keys()
+		for edge_key in edge_keys:
+			var edge = original.edges[edge_key]
+			if edge.from.id == node:
+				original.edges.erase(edge_key)
+		
+	return original
+
+
+func get_children_from_selection(node_id, new_cloudgraph) -> Dictionary:
+	var edge_keys = _g.main_graph.graph_data.edges.keys()
+	for edge_key in edge_keys:
+		var connection = _g.main_graph.graph_data.edges[ edge_key ]
+		if connection.from.id == node_id:
+			new_cloudgraph.edges[edge_key] = connection
+	
+	var nodes = _g.main_graph.graph_data.nodes
+	for connection in new_cloudgraph.edges.values():
+		var connection_id = connection.to.id
+		if nodes.has(connection_id) and connection_id != node_id:
+			new_cloudgraph.nodes[connection_id] = nodes[connection_id]
+	
+	return new_cloudgraph

--- a/ckui/src/ui/views/scripts/ui_graph.gd
+++ b/ckui/src/ui/views/scripts/ui_graph.gd
@@ -160,8 +160,8 @@ func zoom_in():
 	cam_tween.start()
 
 
-func go_to_graph_node(node_id) -> void:
-	if !is_active:
+func go_to_graph_node(node_id, graph) -> void:
+	if !is_active or graph != _g.main_graph:
 		return
 	if target_node != null:
 		target_node.icon.is_selected = false
@@ -175,6 +175,7 @@ func go_to_graph_node(node_id) -> void:
 	var target_pos = target_node.icon.global_position
 	var target_zoom = target_node.icon.scale
 	var flytime = range_lerp(clamp(target_pos.distance_to(graph_cam.global_position), 100, 1000), 100, 1000, 0.35, 1.5)
+	cam_tween.remove_all()
 	cam_tween.interpolate_property(graph_cam, "global_position", graph_cam.global_position, target_pos, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
 	cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, target_zoom*0.5, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
 	cam_tween.start()

--- a/ckui/src/ui/views/scripts/ui_graph.gd
+++ b/ckui/src/ui/views/scripts/ui_graph.gd
@@ -1,0 +1,179 @@
+extends Node2D
+
+const GRAPH_DUMP_JSON_PATH = "res://data/graph_dump.json"
+const GRAPH_NODE_JSON_PATH := "res://data/graph_node_positions.json"
+
+var root_node : Object = null
+var mouse_is_pressed := false
+var last_drag_pos := Vector2.ZERO
+var new_drag_pos := Vector2.ZERO
+var is_dragging_cam := false
+var drag_sensitivity := 1.0
+var drag_power := Vector2.ZERO
+var target_node : CloudNode = null
+var cam_moving := false
+var selected_new_node := false
+var original_zoom := Vector2.ONE
+var spaceship : Object = null
+var Spaceship = preload("res://ui/elements/Element_Spaceship.tscn")
+
+onready var graph_cam = $GraphCam
+onready var cam_tween = $CamMoveTween
+onready var graph_bg = $BG/BG
+
+export (NodePath) onready var main_ui = get_node(main_ui)
+
+func _ready():
+	_g.main_graph = $GraphView
+	_g.connect("load_nodes", self, "read_data")
+	_e.connect("graph_order", self, "main_graph_order")
+	_e.connect("graph_randomize", self, "main_graph_rand")
+	_e.connect("graph_spaceship", self, "update_spaceship_mode")
+	_e.connect("go_to_graph_node", self, "go_to_graph_node")
+
+
+func _process(delta):
+	if root_node == null:
+		return
+	
+	# move the center of the background gradient in the direction of the root node
+	var dist_to_root_node = min(root_node.global_position.distance_to(graph_cam.global_position), 2000)
+	var dir_to_root_node = root_node.global_position.direction_to(graph_cam.global_position)
+	var zoom_factor = range_lerp(graph_cam.zoom.x, 0.5, 4, 1, 0.1)
+	graph_bg.material.set_shader_param("center", -dir_to_root_node * ease(range_lerp(dist_to_root_node, 0, 2000, 0, 1), 0.7) * zoom_factor)
+
+
+func read_data():
+	var file = File.new()
+	var new_data := {}
+	
+	if file.file_exists(GRAPH_DUMP_JSON_PATH) and !_g.use_example_data:
+		file.open(GRAPH_DUMP_JSON_PATH, file.READ)
+		
+		var index = 0
+		while not file.eof_reached():
+			var line = file.get_line()
+			if line == "":
+				index += 1
+				continue
+			new_data[index] = parse_json(line)
+			index += 1
+	
+		file.close()
+	else:
+		var example_data_file = load("res://scripts/tools/example_data.gd")
+		var example_data = example_data_file.new()
+		new_data = example_data.graph_data.duplicate()
+	
+	var graph_node_positions = Utils.load_json(GRAPH_NODE_JSON_PATH)
+	_g.main_graph.create_graph(new_data)
+	_g.main_graph.layout_graph(graph_node_positions)
+	root_node = _g.main_graph.root_node
+	graph_cam.global_position = root_node.global_position
+	graph_cam.zoom = Vector2.ONE*0.8
+
+
+func main_graph_order():
+	var saved_node_positions = _g.main_graph.graph_calc_layout()
+	Utils.save_json(GRAPH_NODE_JSON_PATH, saved_node_positions)
+
+
+func main_graph_rand():
+	_g.main_graph.graph_rand_layout()
+
+
+func _physics_process(delta):
+	mouse_is_pressed = Input.is_action_pressed("left_mouse")
+	var is_in_graph = main_ui.state == main_ui.states.GRAPH
+	if mouse_is_pressed and !target_node and !selected_new_node and is_in_graph and !_g.spaceship_mode:
+		if !is_dragging_cam:
+			is_dragging_cam = true
+			new_drag_pos = get_viewport().get_mouse_position()
+			last_drag_pos = new_drag_pos
+		else:
+			new_drag_pos = get_viewport().get_mouse_position()
+			drag_power = (new_drag_pos-last_drag_pos)
+			last_drag_pos = new_drag_pos
+	else:
+		drag_power *= 50*delta
+		is_dragging_cam = false
+	graph_cam.position -= drag_power*graph_cam.zoom.x
+	
+	if is_in_graph:
+		if Input.is_action_just_released("zoom_in"):
+			graph_cam.zoom = max(graph_cam.zoom.x * 0.95, 0.2) * Vector2.ONE
+		elif Input.is_action_just_released("zoom_out"):
+			graph_cam.zoom = min(graph_cam.zoom.x * 1.05, 4) * Vector2.ONE
+	
+	if _g.spaceship_mode:
+		graph_cam.global_position = spaceship.global_position
+
+func update_spaceship_mode():
+	if _g.spaceship_mode:
+		spaceship = Spaceship.instance()
+		add_child(spaceship)
+		spaceship.global_position = graph_cam.global_position
+		spaceship.appear()
+		cam_tween.remove_all()
+		cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2(0.2,0.2), 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+		cam_tween.start()
+	else:
+		cam_tween.remove_all()
+		cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE, 0.3, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+		cam_tween.start()
+		spaceship.vanish()
+		spaceship = null
+
+
+func zoom_out():
+	original_zoom = graph_cam.zoom
+	cam_tween.remove_all()
+	cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE*0.4, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
+	cam_tween.start()
+
+
+func zoom_in():
+	cam_tween.remove_all()
+	cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, original_zoom, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
+	cam_tween.start()
+
+
+func go_to_graph_node(node_id) -> void:
+	if target_node != null:
+		target_node.icon.is_selected = false
+	
+	target_node = _g.main_graph.graph_data.nodes[node_id]
+	_e.emit_signal("hide_nodes")
+	_e.emit_signal("show_node", node_id)
+	
+	selected_new_node = true
+	$NewNodeSelectionTimer.start()
+	var target_pos = target_node.icon.global_position
+	var target_zoom = target_node.icon.scale
+	var flytime = range_lerp(clamp(target_pos.distance_to(graph_cam.global_position), 100, 1000), 100, 1000, 0.35, 1.5)
+	cam_tween.interpolate_property(graph_cam, "global_position", graph_cam.global_position, target_pos, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+	cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, target_zoom*0.5, flytime, Tween.TRANS_QUART, Tween.EASE_IN_OUT)
+	cam_tween.start()
+	target_node.icon.is_selected = true
+	cam_moving = true
+
+
+func _on_CamMoveTween_tween_all_completed() -> void:
+	if target_node != null and cam_moving:
+		cam_moving = false
+		_e.emit_signal("nodeinfo_show", target_node)
+
+
+func _on_NewNodeSelectionTimer_timeout():
+	selected_new_node = false
+
+
+func _on_MouseDetector_input_event(_viewport, event, _shape_idx):
+	if event is InputEventMouseButton:
+		if !event.pressed and !selected_new_node and target_node != null:
+			cam_tween.interpolate_property(graph_cam, "zoom", graph_cam.zoom, Vector2.ONE*0.8, 0.7, Tween.TRANS_EXPO, Tween.EASE_OUT)
+			cam_tween.start()
+			target_node.icon.is_selected = false
+			target_node = null
+			cam_moving = false
+			_e.emit_signal("nodeinfo_hide")

--- a/ckui/src/ui/views/scripts/ui_graph.gd
+++ b/ckui/src/ui/views/scripts/ui_graph.gd
@@ -169,7 +169,7 @@ func go_to_graph_node(node_id) -> void:
 	target_node.icon.is_selected = true
 	cam_moving = true
 	
-	print(_g.main_graph.create_cloudgraph_from_selection(node_id))
+	_g.main_graph.get_blastradius_from_selection(node_id)
 
 
 func _on_CamMoveTween_tween_all_completed() -> void:

--- a/ckui/src/ui/views/scripts/ui_graph.gd
+++ b/ckui/src/ui/views/scripts/ui_graph.gd
@@ -72,13 +72,14 @@ func read_data():
 		var new_graph_node_positions = Utils.load_json(GRAPH_NODE_JSON_PATH)
 		if typeof(new_graph_node_positions) == TYPE_DICTIONARY:
 			graph_node_positions = new_graph_node_positions
-	_g.main_graph.create_graph(new_data)
+	_g.main_graph.create_graph_raw(new_data)
 	_g.main_graph.layout_graph(graph_node_positions)
 	root_node = _g.main_graph.root_node
 	graph_cam.global_position = root_node.global_position
 	graph_cam.zoom = Vector2.ONE*0.8
 	
 	_e.emit_signal("nodes_changed")
+	_e.emit_signal("hide_nodes")
 
 
 func main_graph_order():
@@ -168,8 +169,6 @@ func go_to_graph_node(node_id) -> void:
 	cam_tween.start()
 	target_node.icon.is_selected = true
 	cam_moving = true
-	
-	_g.main_graph.get_blastradius_from_selection(node_id)
 
 
 func _on_CamMoveTween_tween_all_completed() -> void:

--- a/ckui/src/ui/views/scripts/ui_node_info.gd
+++ b/ckui/src/ui/views/scripts/ui_node_info.gd
@@ -9,6 +9,8 @@ onready var orig_pos = rect_position
 func _ready() -> void:
 	hide()
 	rect_position.y = orig_pos.y + 300
+	_e.connect("nodeinfo_show", self, "show_info")
+	_e.connect("nodeinfo_hide", self, "hide_info")
 
 
 func hide_info() -> void:

--- a/ckui/src/ui/views/scripts/ui_node_info.gd
+++ b/ckui/src/ui/views/scripts/ui_node_info.gd
@@ -5,6 +5,7 @@ var is_visible := false
 onready var anim_tween = $AnimTween
 onready var orig_pos = rect_position
 
+var selected_node : CloudNode = null
 
 func _ready() -> void:
 	hide()
@@ -14,12 +15,14 @@ func _ready() -> void:
 
 
 func hide_info() -> void:
+	selected_node = null
 	anim_tween.interpolate_property(self, "modulate:a", modulate.a, 0, 0.2, Tween.TRANS_QUART, Tween.EASE_OUT)
 	anim_tween.interpolate_property(self, "rect_position:y", rect_position.y, orig_pos.y + 300, 0.3, Tween.TRANS_QUART, Tween.EASE_OUT)
 	anim_tween.start()
 
 
 func show_info(target_node) -> void:
+	selected_node = target_node
 	$Background/NodeNameLabel.text = target_node.reported.name
 	$Background/NodeNameLabel/NodeKindLabel.text = target_node.reported.kind
 	
@@ -49,3 +52,7 @@ func _on_AnimTween_tween_all_completed() -> void:
 		is_visible = false
 	elif is_visible and modulate.a == 1:
 		is_visible = true
+
+
+func _on_MarkForCleanupButton_pressed():
+	_e.emit_signal("show_blastradius", selected_node.id)

--- a/ckui/src/ui/views/scripts/ui_search.gd
+++ b/ckui/src/ui/views/scripts/ui_search.gd
@@ -8,7 +8,7 @@ onready var cloud_results = $ResultContainer/Results/HBoxContainer/CloudResults/
 onready var query_results = $ResultContainer/Results/HBoxContainer/QueryResults/Items
 
 func _ready():
-	_g.connect("nodes_changed", self, "set_local_nodes")
+	_e.connect("nodes_changed", self, "set_local_nodes")
 
 func grab_focus():
 	$ResultContainer.hide()
@@ -22,7 +22,7 @@ func grab_focus():
 
 
 func set_local_nodes():
-	nodes = _g.nodes.duplicate()
+	nodes = _g.main_graph.graph_data.nodes.duplicate()
 
 
 func _on_LineEdit_text_changed(_new_text):

--- a/ckui/src/ui/views/scripts/ui_topbar.gd
+++ b/ckui/src/ui/views/scripts/ui_topbar.gd
@@ -2,16 +2,19 @@ extends Control
 
 enum states {GRAPH, SEARCH, DASHBOARD, QUERY}
 
-onready var buttons = [$Buttons/TopButton_Nodes, $Buttons/TopButton_Search, $Buttons/TopButton_Dashboard, $Buttons/TopButton_Query, $Buttons/TopButton_Dashboard]
+onready var buttons = [$Buttons/TopButton_Nodes, $Buttons/TopButton_Search, $Buttons/TopButton_Dashboard, $Buttons/TopButton_Query, null]
 
 func _ready():
 	for i in buttons.size():
-		buttons[i].connect("pressed", self, "change_section", [i])
+		if buttons[i] != null:
+			buttons[i].connect("pressed", self, "change_section", [i])
 
 
 func change_button(old_state, new_state):
-	buttons[old_state].active = false
-	buttons[new_state].active = true
+	if buttons[old_state] != null:
+		buttons[old_state].active = false
+	if buttons[new_state] != null:
+		buttons[new_state].active = true
 
 func change_section(state_id):
 	_g.interface.state = state_id

--- a/ckui/src/ui/views/scripts/ui_topbar.gd
+++ b/ckui/src/ui/views/scripts/ui_topbar.gd
@@ -2,7 +2,7 @@ extends Control
 
 enum states {GRAPH, SEARCH, DASHBOARD, QUERY}
 
-onready var buttons = [$Buttons/TopButton_Nodes, $Buttons/TopButton_Search, $Buttons/TopButton_Dashboard, $Buttons/TopButton_Query]
+onready var buttons = [$Buttons/TopButton_Nodes, $Buttons/TopButton_Search, $Buttons/TopButton_Dashboard, $Buttons/TopButton_Query, $Buttons/TopButton_Dashboard]
 
 func _ready():
 	for i in buttons.size():


### PR DESCRIPTION
- A new blast radius ui was added. You will see it when clicking "mark for cleanup" on a node.
- The bottom command line was made smaller
- 'connections' were renamed to 'edges' in all scripts
- The graph view was refactored into a separate class, this will make it easier to use it in different ui elements (such as blast radius, the main graph or a dashboard element)
- A problem with copying and duplicating graph data was fixed by making a true deep copy of the graph data.