### PR TITLE
[ckcore] Add support for subqueries

### DIFF
--- a/ckcore/.pylintrc
+++ b/ckcore/.pylintrc
@@ -73,7 +73,8 @@ disable=
     too-many-statements,
     invalid-overridden-method,
     unsubscriptable-object,
-    duplicate-code # pylint also checks duplicated import statements - does not make any sense
+    duplicate-code, # pylint also checks duplicated import statements - does not make any sense
+    too-many-boolean-expressions
 
 
 [REPORTS]

--- a/ckcore/.pylintrc
+++ b/ckcore/.pylintrc
@@ -72,7 +72,8 @@ disable=
     broad-except,
     too-many-statements,
     invalid-overridden-method,
-    unsubscriptable-object
+    unsubscriptable-object,
+    duplicate-code # pylint also checks duplicated import statements - does not make any sense
 
 
 [REPORTS]

--- a/ckcore/core/db/arango_query.py
+++ b/ckcore/core/db/arango_query.py
@@ -186,10 +186,13 @@ def query_string(
             merge_crsr = next_crs("merge_part")
             # make sure the limit only yields one element
             mg_crs, mg_query = query_string(
-                db, q.query.with_limit(1), query_model, merge_cursor, with_edges, bind_vars, counters, merge_crsr
+                db, q.query, query_model, merge_cursor, with_edges, bind_vars, counters, merge_crsr
             )
             part_res = next_crs("part_res")
-            merge_result += f"LET {part_res}=FIRST({mg_query} FOR r in {mg_crs} LIMIT 1 RETURN r)"
+            if q.query.aggregate:
+                merge_result += f"LET {part_res}=({mg_query} FOR r in {mg_crs} RETURN r)"
+            else:
+                merge_result += f"LET {part_res}=FIRST({mg_query} FOR r in {mg_crs} LIMIT 1 RETURN r)"
             merge_parts.append(f"{q.name}: {part_res}")
 
         final_merge = f'RETURN MERGE({merge_cursor}, {{{", ".join(merge_parts)}}}))'

--- a/ckcore/core/db/arango_query.py
+++ b/ckcore/core/db/arango_query.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import Union, List, Tuple, Any, Iterator
+from collections import defaultdict
+from typing import Union, List, Tuple, Any, Optional, Dict
 
 from arango.typings import Json
 
@@ -32,15 +33,17 @@ from core.query.model import (
     Query,
 )
 from core.query.query_parser import merge_ancestors_parser
-from core.util import count_iterator
 
 log = logging.getLogger(__name__)
 
+allowed_first_merge_part = Part(AllTerm())
+
 
 def to_query(db: Any, query_model: QueryModel, with_edges: bool = False) -> Tuple[str, Json]:
-    count = count_iterator()
+    count: Dict[str, int] = defaultdict(lambda: 0)
+    query = query_model.query
     bind_vars: Json = {}
-    cursor, query_str = query_string(db, query_model.query, query_model, db.vertex_name, with_edges, bind_vars, count)
+    cursor, query_str = query_string(db, query, query_model, db.vertex_name, with_edges, bind_vars, count)
     return f"""{query_str} FOR result in {cursor} RETURN result""", bind_vars
 
 
@@ -51,21 +54,27 @@ def query_string(
     start_cursor: str,
     with_edges: bool,
     bind_vars: Json,
-    count: Iterator[int],
+    counters: Dict[str, int],
+    outer_merge: Optional[str] = None,
 ) -> Tuple[str, str]:
     model = query_model.model
     section_dot = f"{query_model.query_section}." if query_model.query_section else ""
     mw = query.preamble.get("merge_with_ancestors")
     merge_with: List[str] = re.split("\\s*,\\s*", str(mw)) if mw else []
 
-    def next_crs() -> str:
-        return f"n{next(count)}"
+    def next_counter(name: str) -> int:
+        count = counters[name]
+        counters[name] = count + 1
+        return count
+
+    def next_crs(name: str = "m") -> str:
+        return f"{name}{next_counter(name)}"
 
     def next_bind_var_name() -> str:
-        return f"b{next(count)}"
+        return f'b{next_counter("bind_vars")}'
 
     def aggregate(in_cursor: str, a: Aggregate) -> Tuple[str, str]:
-        cursor = next_crs()
+        cursor = next_crs("agg")
 
         def var_name(n: Union[AggregateVariableName, AggregateVariableCombined]) -> str:
             def comb_name(cb: Union[str, AggregateVariableName]) -> str:
@@ -164,38 +173,44 @@ def query_string(
             raise AttributeError(f"Do not understand: {ab_term}")
 
     def merge(cursor: str, merge_queries: List[MergeQuery]) -> Tuple[str, str]:  # cursor, query
-        merge_name = f"merge{next(count)}"
-        merge_result = ""
+        result_cursor = next_crs("merge_result")
+        merge_cursor = next_crs()
+        merge_result = f"LET {result_cursor} = (FOR {merge_cursor} in {cursor} "
         merge_parts = []
         for q in merge_queries:
-            merge_crsr = next_crs()
-            inter_crsr = next_crs()
+            # make sure the first
+            f = q.query.parts[-1]
+            assert (
+                f.term == AllTerm() and not f.sort and not f.limit and not f.with_clause and not f.tag
+            ), "Merge query needs to start with navigation!"
+            merge_crsr = next_crs("merge_part")
             # make sure the limit only yields one element
             mg_crs, mg_query = query_string(
-                db, q.query.with_limit(1), query_model, cursor, with_edges, bind_vars, count
+                db, q.query.with_limit(1), query_model, merge_cursor, with_edges, bind_vars, counters, merge_crsr
             )
-            merge_result += f"LET {merge_crsr}=({mg_query} FOR {inter_crsr} in {mg_crs} RETURN {inter_crsr})"
-            merge_parts.append(f"{q.name}: FIRST({merge_crsr})")
+            part_res = next_crs("part_res")
+            merge_result += f"LET {part_res}=FIRST({mg_query} FOR r in {mg_crs} LIMIT 1 RETURN r)"
+            merge_parts.append(f"{q.name}: {part_res}")
 
-        result_crs = next_crs()
-        final_merge = f'FOR {result_crs} IN {cursor} RETURN MERGE({result_crs}, {{{", ".join(merge_parts)}}})'
-        return merge_name, f"LET {merge_name}=({merge_result} {final_merge})"
+        final_merge = f'RETURN MERGE({merge_cursor}, {{{", ".join(merge_parts)}}}))'
+        return result_cursor, f"{merge_result} {final_merge}"
 
-    def part(p: Part, in_cursor: str) -> Tuple[Part, str, str, str]:
+    def part(p: Part, in_cursor: str, part_idx: int) -> Tuple[Part, str, str, str]:
         query_part = ""
         filtered_out = ""
 
         def filter_statement(current_cursor: str, part_term: Term) -> str:
+            if isinstance(part_term, AllTerm) and p.limit is None and not p.sort:
+                return current_cursor
             nonlocal query_part, filtered_out
             crsr = next_crs()
-            filtered_out = next_crs()
+            filtered_out = next_crs("filter")
             md = f"NOT_NULL({crsr}.metadata, {{}})"
             f_res = f'MERGE({crsr}, {{metadata:MERGE({md}, {{"query_tag": "{p.tag}"}})}})' if p.tag else crsr
             limited = f" LIMIT {p.limit} " if p.limit else " "
             sort_by = sort(crsr, p.sort, section_dot) if p.sort else " "
             for_stmt = f"FOR {crsr} in {current_cursor} FILTER {term(crsr, part_term)}{sort_by}{limited}RETURN {f_res}"
             query_part += f"LET {filtered_out} = ({for_stmt})"
-            print(f"filter: LET {filtered_out} = ({for_stmt})")
             return filtered_out
 
         def with_clause(in_crsr: str, clause: WithClause) -> str:
@@ -219,7 +234,7 @@ def query_string(
             # COLLECT l2_cloud = l3_cloud WITH COUNT INTO counter1
             # FILTER (counter1>=0) //counter is +1 since the node itself is always bypassed
             # RETURN ({cloud: l2_cloud._key, count:counter1})
-            current = next(count)
+            current = next_counter("with_clause")
 
             def cursor_in(depth: int) -> str:
                 return f"c{current}_{depth}"
@@ -271,16 +286,24 @@ def query_string(
 
         def inout(in_crsr: str, start: int, until: int, edge_type: str, direction: str) -> str:
             nonlocal query_part
-            in_c = next_crs()
-            out = next_crs()
-            out_crsr = next_crs()
-            link = next_crs()
+            in_c = next_crs("io_in")
+            out = next_crs("io_out")
+            out_crsr = next_crs("io_crs")
+            link = next_crs("io_link")
             unique = "uniqueEdges: 'path'" if with_edges else "uniqueVertices: 'global'"
+            link_str = f", {link}" if with_edges else ""
             dir_bound = "OUTBOUND" if direction == "out" else "INBOUND"
             inout_result = f"MERGE({out_crsr}, {{_from:{link}._from, _to:{link}._to}})" if with_edges else out_crsr
+            if outer_merge and part_idx == 0:
+                graph_cursor = in_crsr
+                outer_for = ""
+            else:
+                graph_cursor = in_c
+                outer_for = f"FOR {in_c} in {in_crsr} "
+
             query_part += (
-                f"LET {out} =( FOR {in_c} in {in_crsr} "
-                f"FOR {out_crsr}, {link} IN {start}..{until} {dir_bound} {in_c} "
+                f"LET {out} =({outer_for}"
+                f"FOR {out_crsr}{link_str} IN {start}..{until} {dir_bound} {graph_cursor} "
                 f"{db.edge_collection(edge_type)} OPTIONS {{ bfs: true, {unique} }} "
                 f"RETURN DISTINCT {inout_result}) "
             )
@@ -303,8 +326,9 @@ def query_string(
             filter_cursor = filter_statement(in_cursor, p.term.pre_filter)
             cursor, merge_part = merge(filter_cursor, p.term.merge)
             query_part += merge_part
-            if p.term.post_filter:
-                cursor = filter_statement(cursor, p.term.post_filter)
+            post = p.term.post_filter if p.term.post_filter else AllTerm()
+            # always do the post filter in case of sort or limit
+            cursor = filter_statement(cursor, post)
         else:
             cursor = filter_statement(in_cursor, p.term)
         cursor = with_clause(cursor, p.with_clause) if p.with_clause else cursor
@@ -353,8 +377,8 @@ def query_string(
 
     parts = []
     crsr = start_cursor
-    for p in reversed(query.parts):
-        part_tuple = part(p, crsr)
+    for idx, p in enumerate(reversed(query.parts)):
+        part_tuple = part(p, crsr, idx)
         parts.append(part_tuple)
         crsr = part_tuple[1]
 

--- a/ckcore/core/db/arango_query.py
+++ b/ckcore/core/db/arango_query.py
@@ -1,0 +1,343 @@
+import logging
+import re
+from typing import Union, List, Tuple, Any, Iterator
+
+from arango.typings import Json
+
+from core.constants import less_greater_then_operations as lgt_ops, arangodb_matches_null_ops
+from core.db.arangodb_functions import as_arangodb_function
+from core.db.model import QueryModel
+from core.model.graph_access import EdgeType, Section
+from core.model.model import SyntheticProperty
+from core.model.resolve_in_graph import GraphResolver
+from core.query.model import (
+    Predicate,
+    IsTerm,
+    Part,
+    Term,
+    CombinedTerm,
+    FunctionTerm,
+    Navigation,
+    IdTerm,
+    Aggregate,
+    AllTerm,
+    AggregateFunction,
+    Sort,
+    WithClause,
+    AggregateVariableName,
+    AggregateVariableCombined,
+    NotTerm,
+)
+from core.query.query_parser import merge_ancestors_parser
+from core.util import count_iterator
+
+log = logging.getLogger(__name__)
+
+
+def to_query(db: Any, query_model: QueryModel, with_edges: bool = False) -> Tuple[str, Json]:
+    count = count_iterator()
+    cursor, query_str, bind_vars = query_string(db, query_model, with_edges, count)
+    return f"""{query_str} FOR result in {cursor} RETURN result""", bind_vars
+
+
+def query_string(db: Any, query_model: QueryModel, with_edges: bool, count: Iterator[int]) -> Tuple[str, str, Json]:
+    query = query_model.query
+    model = query_model.model
+    section_dot = f"{query_model.query_section}." if query_model.query_section else ""
+    mw = query.preamble.get("merge_with_ancestors")
+    merge_with: List[str] = re.split("\\s*,\\s*", str(mw)) if mw else []
+    bind_vars: Json = {}
+
+    def next_crs() -> str:
+        return f"n{next(count)}"
+
+    def next_bind_var_name() -> str:
+        return f"b{next(count)}"
+
+    def aggregate(in_cursor: str, a: Aggregate) -> Tuple[str, str]:
+        cursor = next_crs()
+
+        def var_name(n: Union[AggregateVariableName, AggregateVariableCombined]) -> str:
+            def comb_name(cb: Union[str, AggregateVariableName]) -> str:
+                return f'"{cb}"' if isinstance(cb, str) else f"{cursor}.{section_dot}{cb.name}"
+
+            return (
+                f"{cursor}.{section_dot}{n.name}"
+                if isinstance(n, AggregateVariableName)
+                else f'CONCAT({",".join(comb_name(cp) for cp in n.parts)})'
+            )
+
+        def func_term(fn: AggregateFunction) -> str:
+            name = f"{cursor}.{section_dot}{fn.name}" if isinstance(fn.name, str) else str(fn.name)
+            return f"{name} {fn.combined_ops()}" if fn.ops else name
+
+        vs = {str(v.name): f"var_{num}" for num, v in enumerate(a.group_by)}
+        fs = {v.name: f"fn_{num}" for num, v in enumerate(a.group_func)}
+        variables = ", ".join(f"{vs[str(v.name)]}={var_name(v.name)}" for v in a.group_by)
+        funcs = ", ".join(f"{fs[v.name]}={v.function}({func_term(v)})" for v in a.group_func)
+        agg_vars = ", ".join(f'"{v.get_as_name()}": {vs[str(v.name)]}' for v in a.group_by)
+        agg_funcs = ", ".join(f'"{f.get_as_name()}": {fs[f.name]}' for f in a.group_func)
+        group_result = f'"group":{{{agg_vars}}},' if a.group_by else ""
+        aggregate_term = f"collect {variables} aggregate {funcs}"
+        return_result = f"{{{group_result} {agg_funcs}}}"
+        return (
+            "aggregated",
+            f"LET aggregated = (for {cursor} in {in_cursor} {aggregate_term} RETURN {return_result})",
+        )
+
+    def predicate(cursor: str, p: Predicate) -> str:
+        extra = ""
+        path = p.name
+
+        # handle that property is an array
+        if "array" in p.args:
+            arr_filter = p.args["filter"] if "filter" in p.args else "any"
+            extra = f" {arr_filter} "
+            path = f"{p.name}[]"
+        elif "[*]" in p.name:
+            extra = " any " if "[*]" in p.name else " "
+            path = p.name.replace("[*]", "[]")
+
+        bvn = next_bind_var_name()
+        # if no section is given, the path is prefixed by the section: remove the section
+        lookup = path if query_model.query_section else Section.without_section(path)
+        prop = model.property_by_path(lookup)
+
+        def synthetic_path(synth: SyntheticProperty) -> str:
+            before, after = p.name.rsplit(prop.prop.name, 1)
+            return f'{before}{".".join(synth.path)}{after}'
+
+        op = lgt_ops[p.op] if prop.kind.reverse_order and p.op in lgt_ops else p.op
+        if op in ["in", "not in"] and isinstance(p.value, list):
+            bind_vars[bvn] = [prop.kind.coerce(a) for a in p.value]
+        else:
+            bind_vars[bvn] = prop.kind.coerce(p.value)
+        prop_name = synthetic_path(prop.prop.synthetic) if prop.prop.synthetic else p.name
+        var_name = f"{cursor}.{section_dot}{prop_name}"
+        p_term = f"{var_name}{extra} {op} @{bvn}"
+        # null check is required, since x<anything evaluates to true if x is null!
+        return f"({var_name}!=null and {p_term})" if op in arangodb_matches_null_ops else p_term
+
+    def with_id(cursor: str, t: IdTerm) -> str:
+        bvn = next_bind_var_name()
+        bind_vars[bvn] = t.id
+        return f"{cursor}._key == @{bvn}"
+
+    def is_instance(cursor: str, t: IsTerm) -> str:
+        if t.kind not in model:
+            raise AttributeError(f"Given kind does not exist: {t.kind}")
+        bvn = next_bind_var_name()
+        bind_vars[bvn] = t.kind
+        return f"@{bvn} IN {cursor}.kinds"
+
+    def not_term(cursor: str, t: NotTerm) -> str:
+        return f"NOT ({term(cursor, t.term)})"
+
+    def term(cursor: str, ab_term: Term) -> str:
+        if isinstance(ab_term, AllTerm):
+            return "true"
+        if isinstance(ab_term, Predicate):
+            return predicate(cursor, ab_term)
+        elif isinstance(ab_term, FunctionTerm):
+            return as_arangodb_function(cursor, bind_vars, ab_term, query_model)
+        elif isinstance(ab_term, IdTerm):
+            return with_id(cursor, ab_term)
+        elif isinstance(ab_term, IsTerm):
+            return is_instance(cursor, ab_term)
+        elif isinstance(ab_term, NotTerm):
+            return not_term(cursor, ab_term)
+        elif isinstance(ab_term, CombinedTerm):
+            left = term(cursor, ab_term.left)
+            right = term(cursor, ab_term.right)
+            return f"({left}) {ab_term.op} ({right})"
+        else:
+            raise AttributeError(f"Do not understand: {ab_term}")
+
+    def part(p: Part, in_cursor: str) -> Tuple[Part, str, str, str]:
+        query_part = ""
+        filtered_out = next_crs()
+
+        def filter_statement() -> str:
+            nonlocal query_part
+            crsr = next_crs()
+            out = filtered_out
+            md = f"NOT_NULL({crsr}.metadata, {{}})"
+            f_res = f'MERGE({crsr}, {{metadata:MERGE({md}, {{"query_tag": "{p.tag}"}})}})' if p.tag else crsr
+            limited = f" LIMIT {p.limit} " if p.limit else " "
+            sort_by = sort(crsr, p.sort, section_dot) if p.sort else " "
+            for_stmt = f"FOR {crsr} in {in_cursor} FILTER {term(crsr, p.term)}{sort_by}{limited}RETURN {f_res}"
+            query_part += f"LET {out} = ({for_stmt})"
+            return out
+
+        def with_clause(in_crsr: str, clause: WithClause) -> str:
+            nonlocal query_part
+            # this is the general structure of the with_clause that is created
+            #
+            # FOR cloud in foo FILTER @0 in cloud.kinds
+            #    FOR account IN 0..1 OUTBOUND cloud foo_dependency
+            #    OPTIONS { bfs: true, uniqueVertices: 'global' }
+            #    FILTER (cloud._key==account._key) or (@1 in account.kinds)
+            #        FOR region in 0..1 OUTBOUND account foo_dependency
+            #        OPTIONS { bfs: true, uniqueVertices: 'global' }
+            #         FILTER (cloud._key==region._key) or (@2 in region.kinds)
+            #             FOR zone in 0..1 OUTBOUND region foo_dependency
+            #             OPTIONS { bfs: true, uniqueVertices: 'global' }
+            #             FILTER (cloud._key==zone._key) or (@3 in zone.kinds)
+            #         COLLECT l4_cloud = cloud, l4_account=account, l4_region=region WITH COUNT INTO counter3
+            #         FILTER (l4_cloud._key==l4_region._key) or (counter3>=0)
+            #     COLLECT l3_cloud = l4_cloud, l3_account=l4_account WITH COUNT INTO counter2
+            #     FILTER (l3_cloud._key==l3_account._key) or (counter2>=0) // ==2 regions
+            # COLLECT l2_cloud = l3_cloud WITH COUNT INTO counter1
+            # FILTER (counter1>=0) //counter is +1 since the node itself is always bypassed
+            # RETURN ({cloud: l2_cloud._key, count:counter1})
+            current = next(count)
+
+            def cursor_in(depth: int) -> str:
+                return f"c{current}_{depth}"
+
+            l0crsr = cursor_in(0)
+
+            def traversal_filter(cl: WithClause, in_crs: str, depth: int) -> str:
+                nav = cl.navigation
+                crsr = cursor_in(depth)
+                direction = "OUTBOUND" if nav.direction == "out" else "INBOUND"
+                unique = "uniqueEdges: 'path'" if with_edges else "uniqueVertices: 'global'"
+                filter_clause = f"({term(crsr, cl.term)})" if cl.term else "true"
+                inner = traversal_filter(cl.with_clause, crsr, depth + 1) if cl.with_clause else ""
+                filter_root = f"({l0crsr}._key=={crsr}._key) or " if depth > 0 else ""
+                return (
+                    f"FOR {crsr} IN 0..{nav.until} {direction} {in_crs} "
+                    f"{db.edge_collection(nav.edge_type)} OPTIONS {{ bfs: true, {unique} }} "
+                    f"FILTER {filter_root}{filter_clause} "
+                ) + inner
+
+            def collect_filter(cl: WithClause, depth: int) -> str:
+                fltr = cl.with_filter
+                if cl.with_clause:
+                    collects = ", ".join(f"l{depth-1}_l{i}_res=l{depth}_l{i}_res" for i in range(0, depth))
+                else:
+                    collects = ", ".join(f"l{depth-1}_l{i}_res={cursor_in(i)}" for i in range(0, depth))
+
+                if depth == 1:
+                    # note: the traversal starts from 0 (only 0 and 1 is allowed)
+                    # when we start from 1: increase the count by one to not count the start node
+                    # when we start from 0: the start node is expected in the count already
+                    filter_term = f"FILTER counter1{fltr.op}{fltr.num + cl.navigation.start}"
+                else:
+                    root_key = f"l{depth-1}_l0_res._key==l{depth-1}_l{depth-1}_res._key"
+                    filter_term = f"FILTER ({root_key}) or (counter{depth}{fltr.op}{fltr.num})"
+
+                inner = collect_filter(cl.with_clause, depth + 1) if cl.with_clause else ""
+                return inner + f"COLLECT {collects} WITH COUNT INTO counter{depth} {filter_term} "
+
+            out = next_crs()
+
+            query_part += (
+                f"LET {out} =( FOR {l0crsr} in {in_crsr} "
+                + traversal_filter(clause, l0crsr, 1)
+                + collect_filter(clause, 1)
+                + "RETURN l0_l0_res) "
+            )
+            return out
+
+        def inout(in_crsr: str, start: int, until: int, edge_type: str, direction: str) -> str:
+            nonlocal query_part
+            in_c = next_crs()
+            out = next_crs()
+            out_crsr = next_crs()
+            link = next_crs()
+            unique = "uniqueEdges: 'path'" if with_edges else "uniqueVertices: 'global'"
+            dir_bound = "OUTBOUND" if direction == "out" else "INBOUND"
+            inout_result = f"MERGE({out_crsr}, {{_from:{link}._from, _to:{link}._to}})" if with_edges else out_crsr
+            query_part += (
+                f"LET {out} =( FOR {in_c} in {in_crsr} "
+                f"FOR {out_crsr}, {link} IN {start}..{until} {dir_bound} {in_c} "
+                f"{db.edge_collection(edge_type)} OPTIONS {{ bfs: true, {unique} }} "
+                f"RETURN DISTINCT {inout_result}) "
+            )
+            return out
+
+        def navigation(in_crsr: str, nav: Navigation) -> str:
+            nonlocal query_part
+            if nav.direction == "inout":
+                # traverse to root
+                to_in = inout(in_crsr, nav.start, nav.until, nav.edge_type, "in")
+                # traverse to leaf (in case of 0: use 1 to not have the current element twice)
+                to_out = inout(in_crsr, max(1, nav.start), nav.until, nav.edge_type, "out")
+                nav_crsr = next_crs()
+                query_part += f"LET {nav_crsr} = UNION({to_in}, {to_out})"
+                return nav_crsr
+            else:
+                return inout(in_crsr, nav.start, nav.until, nav.edge_type, nav.direction)
+
+        cursor = filter_statement()
+        cursor = with_clause(cursor, p.with_clause) if p.with_clause else cursor
+        cursor = navigation(cursor, p.navigation) if p.navigation else cursor
+        return p, cursor, filtered_out, query_part
+
+    def merge_ancestors(cursor: str, part_str: str, ancestor_names: List[str]) -> Tuple[str, str]:
+        ancestors: List[Tuple[str, str]] = [merge_ancestors_parser.parse(p) for p in ancestor_names]
+        m_parts = [f"FOR node in {cursor} "]
+
+        # filter out resolved ancestors: all remaining ancestors need to be looked up in hierarchy
+        to_resolve = [(nr, p_as) for nr, p_as in ancestors if nr not in GraphResolver.resolved_ancestors]
+        if to_resolve:
+            merge_stop_at = next_bind_var_name()
+            merge_ancestor_nodes = next_bind_var_name()
+            bind_vars[merge_stop_at] = to_resolve[0][0]
+            bind_vars[merge_ancestor_nodes] = [tr[0] for tr in to_resolve]
+            m_parts.append(
+                "LET ancestor_nodes = ("
+                + f"FOR p IN 1..1000 INBOUND node {db.edge_collection(EdgeType.default)} "
+                + f"PRUNE @{merge_stop_at} in p.kinds "
+                + "OPTIONS {order: 'bfs', uniqueVertices: 'global'} "
+                + f"FILTER p.kinds any in @{merge_ancestor_nodes} RETURN p)"
+            )
+            for tr, _ in to_resolve:
+                bv = next_bind_var_name()
+                bind_vars[bv] = tr
+                m_parts.append(f"""LET {tr} = FIRST(FOR p IN ancestor_nodes FILTER @{bv} IN p.kinds RETURN p)""")
+
+        # all resolved ancestors can be looked up directly
+        for tr, _ in ancestors:
+            if tr in GraphResolver.resolved_ancestors:
+                m_parts.append(f'LET {tr} = DOCUMENT("{db.vertex_name}", node.refs.{tr}_id)')
+
+        result_parts = []
+        for section in Section.all:
+            ancestor_result = "{" + ",".join([f"{p[1]}: {p[0]}.{section}" for p in ancestors]) + "}"
+            result_parts.append(f"{section}: MERGE(NOT_NULL(node.{section},{{}}), {ancestor_result})")
+
+        m_parts.append("RETURN MERGE(node, {" + ", ".join(result_parts) + "})")
+        return "merge_with_ancestor", part_str + f' LET merge_with_ancestor = ({" ".join(m_parts)})'
+
+    def sort(cursor: str, so: List[Sort], sect_dot: str) -> str:
+        sorts = ", ".join(f"{cursor}.{sect_dot}{s.name} {s.order}" for s in so)
+        return f" SORT {sorts} "
+
+    parts = []
+    crsr = db.vertex_name
+    for p in reversed(query.parts):
+        part_tuple = part(p, crsr)
+        parts.append(part_tuple)
+        crsr = part_tuple[1]
+
+    all_parts = " ".join(p[3] for p in parts)
+    resulting_cursor, query_str = merge_ancestors(crsr, all_parts, merge_with) if merge_with else (crsr, all_parts)
+    nxt = next_crs()
+    if query.aggregate:  # return aggregate
+        resulting_cursor, aggregation = aggregate(resulting_cursor, query.aggregate)
+        query_str += aggregation
+        # if the last part has a sort order, we use it here again
+        if query.current_part.sort:
+            sort_by = sort("res", query.current_part.sort, "")
+            query_str += f" LET {nxt} = (FOR res in {resulting_cursor}{sort_by} RETURN res)"
+            resulting_cursor = nxt
+    else:  # return results
+        # return all tagged commands (last result is "tagged" automatically)
+        tagged = {out for part, _, out, _ in parts if part.tag}
+        if tagged:
+            tagged_union = f'UNION({",".join(tagged)},{resulting_cursor})'
+            query_str += f" LET {nxt} = (FOR res in {tagged_union} RETURN res)"
+            resulting_cursor = nxt
+    return resulting_cursor, query_str, bind_vars

--- a/ckcore/core/db/arango_query.py
+++ b/ckcore/core/db/arango_query.py
@@ -194,10 +194,10 @@ def query_string(
             mg_crs, mg_query = query_string(
                 db, mq.query, query_model, merge_cursor, with_edges, bind_vars, counters, merge_crsr
             )
-            if mq.query.aggregate:
-                merge_result += f"LET {part_result}=({mg_query} FOR r in {mg_crs} RETURN r)"
-            else:
+            if mq.only_first:
                 merge_result += f"LET {part_result}=FIRST({mg_query} FOR r in {mg_crs} LIMIT 1 RETURN r)"
+            else:
+                merge_result += f"LET {part_result}=({mg_query} FOR r in {mg_crs} RETURN DISTINCT r)"
 
         # check if this query points to an already resolved value
         # Currently only resolved ancestors are taken into account:

--- a/ckcore/core/db/graphdb.py
+++ b/ckcore/core/db/graphdb.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
-import re
 import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import partial
-from typing import Optional, Callable, AsyncGenerator, Any, Iterable, Union, Dict, List, Tuple
+from typing import Optional, Callable, AsyncGenerator, Any, Iterable, Dict, List, Tuple
 
 from arango.collection import VertexCollection, StandardCollection, EdgeCollection
 from arango.graph import Graph
@@ -13,8 +12,7 @@ from arango.typings import Json
 from networkx import MultiDiGraph, DiGraph
 
 from core import feature
-from core.constants import less_greater_then_operations as lgt_ops, arangodb_matches_null_ops
-from core.db.arangodb_functions import as_arangodb_function
+from core.db import arango_query
 from core.db.async_arangodb import (
     AsyncArangoDB,
     AsyncArangoTransactionDB,
@@ -26,27 +24,8 @@ from core.error import InvalidBatchUpdate, ConflictingChangeInProgress, NoSuchCh
 from core.message_bus import MessageBus, CoreEvent
 from core.model.adjust_node import AdjustNode
 from core.model.graph_access import GraphAccess, GraphBuilder, EdgeType, Section
-from core.model.model import Model, ComplexKind, SyntheticProperty, TransformKind
-from core.model.resolve_in_graph import NodePath, GraphResolver
-from core.query.model import (
-    Predicate,
-    IsTerm,
-    Part,
-    Term,
-    CombinedTerm,
-    FunctionTerm,
-    Navigation,
-    IdTerm,
-    Aggregate,
-    AllTerm,
-    AggregateFunction,
-    Sort,
-    WithClause,
-    AggregateVariableName,
-    AggregateVariableCombined,
-    NotTerm,
-)
-from core.query.query_parser import merge_ancestors_parser
+from core.model.model import Model, ComplexKind, TransformKind
+from core.model.resolve_in_graph import NodePath
 from core.util import first, value_in_path_get, utc_str, uuid_str, value_in_path, freeze
 
 log = logging.getLogger(__name__)
@@ -761,289 +740,10 @@ class ArangoGraphDB(GraphDB):
         await self.delete_marked_update(batch_id)
 
     def to_query(self, query_model: QueryModel, with_edges: bool = False) -> Tuple[str, Json]:
-        query = query_model.query
-        model = query_model.model
-        section_dot = f"{query_model.query_section}." if query_model.query_section else ""
-        mw = query.preamble.get("merge_with_ancestors")
-        merge_with: List[str] = re.split("\\s*,\\s*", str(mw)) if mw else []
-        bind_vars: Json = {}
-
-        def aggregate(in_cursor: str, a: Aggregate) -> Tuple[str, str]:
-            cursor = "rg"
-
-            def var_name(n: Union[AggregateVariableName, AggregateVariableCombined]) -> str:
-                def comb_name(cb: Union[str, AggregateVariableName]) -> str:
-                    return f'"{cb}"' if isinstance(cb, str) else f"{cursor}.{section_dot}{cb.name}"
-
-                return (
-                    f"{cursor}.{section_dot}{n.name}"
-                    if isinstance(n, AggregateVariableName)
-                    else f'CONCAT({",".join(comb_name(cp) for cp in n.parts)})'
-                )
-
-            def func_term(fn: AggregateFunction) -> str:
-                name = f"{cursor}.{section_dot}{fn.name}" if isinstance(fn.name, str) else str(fn.name)
-                return f"{name} {fn.combined_ops()}" if fn.ops else name
-
-            vs = {str(v.name): f"var_{num}" for num, v in enumerate(a.group_by)}
-            fs = {v.name: f"fn_{num}" for num, v in enumerate(a.group_func)}
-            variables = ", ".join(f"{vs[str(v.name)]}={var_name(v.name)}" for v in a.group_by)
-            funcs = ", ".join(f"{fs[v.name]}={v.function}({func_term(v)})" for v in a.group_func)
-            agg_vars = ", ".join(f'"{v.get_as_name()}": {vs[str(v.name)]}' for v in a.group_by)
-            agg_funcs = ", ".join(f'"{f.get_as_name()}": {fs[f.name]}' for f in a.group_func)
-            group_result = f'"group":{{{agg_vars}}},' if a.group_by else ""
-            aggregate_term = f"collect {variables} aggregate {funcs}"
-            return_result = f"{{{group_result} {agg_funcs}}}"
-            return (
-                "aggregated",
-                f"LET aggregated = (for {cursor} in {in_cursor} {aggregate_term} RETURN {return_result})",
-            )
-
-        def predicate(cursor: str, p: Predicate) -> str:
-            extra = ""
-            path = p.name
-
-            # handle that property is an array
-            if "array" in p.args:
-                arr_filter = p.args["filter"] if "filter" in p.args else "any"
-                extra = f" {arr_filter} "
-                path = f"{p.name}[]"
-            elif "[*]" in p.name:
-                extra = " any " if "[*]" in p.name else " "
-                path = p.name.replace("[*]", "[]")
-
-            # key of the predicate is the len of the dict as string
-            length = str(len(bind_vars))
-            # if no section is given, the path is prefixed by the section: remove the section
-            lookup = path if query_model.query_section else Section.without_section(path)
-            prop = model.property_by_path(lookup)
-
-            def synthetic_path(synth: SyntheticProperty) -> str:
-                before, after = p.name.rsplit(prop.prop.name, 1)
-                return f'{before}{".".join(synth.path)}{after}'
-
-            op = lgt_ops[p.op] if prop.kind.reverse_order and p.op in lgt_ops else p.op
-            if op in ["in", "not in"] and isinstance(p.value, list):
-                bind_vars[length] = [prop.kind.coerce(a) for a in p.value]
-            else:
-                bind_vars[length] = prop.kind.coerce(p.value)
-            prop_name = synthetic_path(prop.prop.synthetic) if prop.prop.synthetic else p.name
-            var_name = f"{cursor}.{section_dot}{prop_name}"
-            p_term = f"{var_name}{extra} {op} @{length}"
-            # null check is required, since x<anything evaluates to true if x is null!
-            return f"({var_name}!=null and {p_term})" if op in arangodb_matches_null_ops else p_term
-
-        def with_id(cursor: str, t: IdTerm) -> str:
-            length = str(len(bind_vars))
-            bind_vars[length] = t.id
-            return f"{cursor}._key == @{length}"
-
-        def is_instance(cursor: str, t: IsTerm) -> str:
-            if t.kind not in model:
-                raise AttributeError(f"Given kind does not exist: {t.kind}")
-            length = str(len(bind_vars))
-            bind_vars[length] = t.kind
-            return f"@{length} IN {cursor}.kinds"
-
-        def not_term(cursor: str, t: NotTerm) -> str:
-            return f"NOT ({term(cursor, t.term)})"
-
-        def term(cursor: str, ab_term: Term) -> str:
-            if isinstance(ab_term, AllTerm):
-                return "true"
-            if isinstance(ab_term, Predicate):
-                return predicate(cursor, ab_term)
-            elif isinstance(ab_term, FunctionTerm):
-                return as_arangodb_function(cursor, bind_vars, ab_term, query_model)
-            elif isinstance(ab_term, IdTerm):
-                return with_id(cursor, ab_term)
-            elif isinstance(ab_term, IsTerm):
-                return is_instance(cursor, ab_term)
-            elif isinstance(ab_term, NotTerm):
-                return not_term(cursor, ab_term)
-            elif isinstance(ab_term, CombinedTerm):
-                left = term(cursor, ab_term.left)
-                right = term(cursor, ab_term.right)
-                return f"({left}) {ab_term.op} ({right})"
-            else:
-                raise AttributeError(f"Do not understand: {ab_term}")
-
-        def part(p: Part, idx: int, in_cursor: str) -> Tuple[Part, str, str, str]:
-            query_part = ""
-            filtered_out = f"step{idx}_filter"
-
-            def filter_statement() -> str:
-                nonlocal query_part
-                crsr = f"f{idx}"
-                out = filtered_out
-                md = f"NOT_NULL({crsr}.metadata, {{}})"
-                f_res = f'MERGE({crsr}, {{metadata:MERGE({md}, {{"query_tag": "{p.tag}"}})}})' if p.tag else crsr
-                limited = f" LIMIT {p.limit} " if p.limit else " "
-                sort_by = sort(crsr, p.sort, section_dot) if p.sort else " "
-                for_stmt = f"FOR {crsr} in {in_cursor} FILTER {term(crsr, p.term)}{sort_by}{limited}RETURN {f_res}"
-                query_part += f"LET {out} = ({for_stmt})"
-                return out
-
-            def with_clause(in_crsr: str, clause: WithClause) -> str:
-                nonlocal query_part
-                # this is the general structure of the with_clause that is created
-                #
-                # FOR cloud in foo FILTER @0 in cloud.kinds
-                #    FOR account IN 0..1 OUTBOUND cloud foo_dependency
-                #    OPTIONS { bfs: true, uniqueVertices: 'global' }
-                #    FILTER (cloud._key==account._key) or (@1 in account.kinds)
-                #        FOR region in 0..1 OUTBOUND account foo_dependency
-                #        OPTIONS { bfs: true, uniqueVertices: 'global' }
-                #         FILTER (cloud._key==region._key) or (@2 in region.kinds)
-                #             FOR zone in 0..1 OUTBOUND region foo_dependency
-                #             OPTIONS { bfs: true, uniqueVertices: 'global' }
-                #             FILTER (cloud._key==zone._key) or (@3 in zone.kinds)
-                #         COLLECT l4_cloud = cloud, l4_account=account, l4_region=region WITH COUNT INTO counter3
-                #         FILTER (l4_cloud._key==l4_region._key) or (counter3>=0)
-                #     COLLECT l3_cloud = l4_cloud, l3_account=l4_account WITH COUNT INTO counter2
-                #     FILTER (l3_cloud._key==l3_account._key) or (counter2>=0) // ==2 regions
-                # COLLECT l2_cloud = l3_cloud WITH COUNT INTO counter1
-                # FILTER (counter1>=0) //counter is +1 since the node itself is always bypassed
-                # RETURN ({cloud: l2_cloud._key, count:counter1})
-
-                def traversal_filter(cl: WithClause, in_crs: str, depth: int) -> str:
-                    nav = cl.navigation
-                    crsr = f"l{depth}crsr"
-                    direction = "OUTBOUND" if nav.direction == "out" else "INBOUND"
-                    unique = "uniqueEdges: 'path'" if with_edges else "uniqueVertices: 'global'"
-                    filter_clause = f"({term(crsr, cl.term)})" if cl.term else "true"
-                    inner = traversal_filter(cl.with_clause, crsr, depth + 1) if cl.with_clause else ""
-                    filter_root = f"(l0crsr._key=={crsr}._key) or " if depth > 0 else ""
-                    return (
-                        f"FOR {crsr} IN 0..{nav.until} {direction} {in_crs} "
-                        f"{self.edge_collection(nav.edge_type)} OPTIONS {{ bfs: true, {unique} }} "
-                        f"FILTER {filter_root}{filter_clause} "
-                    ) + inner
-
-                def collect_filter(cl: WithClause, depth: int) -> str:
-                    fltr = cl.with_filter
-                    if cl.with_clause:
-                        collects = ", ".join(f"l{depth-1}_l{i}_res=l{depth}_l{i}_res" for i in range(0, depth))
-                    else:
-                        collects = ", ".join(f"l{depth-1}_l{i}_res=l{i}crsr" for i in range(0, depth))
-
-                    if depth == 1:
-                        # note: the traversal starts from 0 (only 0 and 1 is allowed)
-                        # when we start from 1: increase the count by one to not count the start node
-                        # when we start from 0: the start node is expected in the count already
-                        filter_term = f"FILTER counter1{fltr.op}{fltr.num + cl.navigation.start}"
-                    else:
-                        root_key = f"l{depth-1}_l0_res._key==l{depth-1}_l{depth-1}_res._key"
-                        filter_term = f"FILTER ({root_key}) or (counter{depth}{fltr.op}{fltr.num})"
-
-                    inner = collect_filter(cl.with_clause, depth + 1) if cl.with_clause else ""
-                    return inner + f"COLLECT {collects} WITH COUNT INTO counter{depth} {filter_term} "
-
-                out = f"step{idx}_with"
-                out_crsr = "l0crsr"
-
-                query_part += (
-                    f"LET {out} =( FOR {out_crsr} in {in_crsr} "
-                    + traversal_filter(clause, out_crsr, 1)
-                    + collect_filter(clause, 1)
-                    + "RETURN l0_l0_res) "
-                )
-                return out
-
-            def inout(in_crsr: str, start: int, until: int, edge_type: str, direction: str) -> str:
-                nonlocal query_part
-                out = f"step{idx}_navigation_{direction}"
-                out_crsr = f"n{idx}"
-                link = f"link{idx}"
-                unique = "uniqueEdges: 'path'" if with_edges else "uniqueVertices: 'global'"
-                dir_bound = "OUTBOUND" if direction == "out" else "INBOUND"
-                inout_result = f"MERGE({out_crsr}, {{_from:{link}._from, _to:{link}._to}})" if with_edges else out_crsr
-                query_part += (
-                    f"LET {out} =( FOR in{idx} in {in_crsr} "
-                    f"FOR {out_crsr}, {link} IN {start}..{until} {dir_bound} in{idx} "
-                    f"{self.edge_collection(edge_type)} OPTIONS {{ bfs: true, {unique} }} "
-                    f"RETURN DISTINCT {inout_result}) "
-                )
-                return out
-
-            def navigation(in_crsr: str, nav: Navigation) -> str:
-                nonlocal query_part
-                if nav.direction == "inout":
-                    # traverse to root
-                    to_in = inout(in_crsr, nav.start, nav.until, nav.edge_type, "in")
-                    # traverse to leaf (in case of 0: use 1 to not have the current element twice)
-                    to_out = inout(in_crsr, max(1, nav.start), nav.until, nav.edge_type, "out")
-                    nav_crsr = f"step{idx}_navigation"
-                    query_part += f"LET {nav_crsr} = UNION({to_in}, {to_out})"
-                    return nav_crsr
-                else:
-                    return inout(in_crsr, nav.start, nav.until, nav.edge_type, nav.direction)
-
-            cursor = filter_statement()
-            cursor = with_clause(cursor, p.with_clause) if p.with_clause else cursor
-            cursor = navigation(cursor, p.navigation) if p.navigation else cursor
-            return p, cursor, filtered_out, query_part
-
-        def merge_ancestors(cursor: str, part_str: str, ancestor_names: List[str]) -> Tuple[str, str]:
-            ancestors: List[Tuple[str, str]] = [merge_ancestors_parser.parse(p) for p in ancestor_names]
-            m_parts = [f"FOR node in {cursor} "]
-
-            # filter out resolved ancestors: all remaining ancestors need to be looked up in hierarchy
-            to_resolve = [(nr, p_as) for nr, p_as in ancestors if nr not in GraphResolver.resolved_ancestors]
-            if to_resolve:
-                bind_vars["merge_stop_at"] = to_resolve[0][0]
-                bind_vars["merge_ancestor_nodes"] = [tr[0] for tr in to_resolve]
-                m_parts.append(
-                    "LET ancestor_nodes = ("
-                    + f"FOR p IN 1..1000 INBOUND node {self.edge_collection(EdgeType.default)} "
-                    + "PRUNE @merge_stop_at in p.kinds "
-                    + "OPTIONS {order: 'bfs', uniqueVertices: 'global'} "
-                    + "FILTER p.kinds any in @merge_ancestor_nodes RETURN p)"
-                )
-                for tr, _ in to_resolve:
-                    bv = f"merge_node_{tr}"
-                    bind_vars[bv] = tr
-                    m_parts.append(f"""LET {tr} = FIRST(FOR p IN ancestor_nodes FILTER @{bv} IN p.kinds RETURN p)""")
-
-            # all resolved ancestors can be looked up directly
-            for tr, _ in ancestors:
-                if tr in GraphResolver.resolved_ancestors:
-                    m_parts.append(f'LET {tr} = DOCUMENT("{self.vertex_name}", node.refs.{tr}_id)')
-
-            result_parts = []
-            for section in Section.all:
-                ancestor_result = "{" + ",".join([f"{p[1]}: {p[0]}.{section}" for p in ancestors]) + "}"
-                result_parts.append(f"{section}: MERGE(NOT_NULL(node.{section},{{}}), {ancestor_result})")
-
-            m_parts.append("RETURN MERGE(node, {" + ", ".join(result_parts) + "})")
-            return "merge_with_ancestor", part_str + f' LET merge_with_ancestor = ({" ".join(m_parts)})'
-
-        def sort(cursor: str, so: List[Sort], sect_dot: str) -> str:
-            sorts = ", ".join(f"{cursor}.{sect_dot}{s.name} {s.order}" for s in so)
-            return f" SORT {sorts} "
-
-        parts = []
-        crsr = self.vertex_name
-        for idx, p in enumerate(reversed(query.parts)):
-            part_tuple = part(p, idx, crsr)
-            parts.append(part_tuple)
-            crsr = part_tuple[1]
-
-        all_parts = " ".join(p[3] for p in parts)
-        resulting_cursor, query_str = merge_ancestors(crsr, all_parts, merge_with) if merge_with else (crsr, all_parts)
-        if query.aggregate:  # return aggregate
-            resulting_cursor, aggregation = aggregate(resulting_cursor, query.aggregate)
-            # if the last part has a sort order, we use it here again
-            sort_by = sort("r", query.current_part.sort, "") if query.current_part.sort else ""
-            return (
-                f"""{query_str} {aggregation} FOR r in {resulting_cursor}{sort_by} RETURN r""",
-                bind_vars,
-            )
-        else:  # return results
-            # return all tagged commands (last result is "tagged" automatically)
-            tagged = {out for part, _, out, _ in parts if part.tag}
-            result = f'UNION({",".join(tagged)},{resulting_cursor})' if tagged else resulting_cursor
-            return f"""{query_str} FOR r in {result} RETURN r""", bind_vars
+        # TODO: remove print
+        result = arango_query.to_query(self, query_model, with_edges)
+        # print(f"\n------\n{result[0]}\n-------\n")
+        return result
 
     async def insert_genesis_data(self) -> None:
         root_data = {"kind": "graph_root", "name": "root"}

--- a/ckcore/core/db/graphdb.py
+++ b/ckcore/core/db/graphdb.py
@@ -398,7 +398,8 @@ class ArangoGraphDB(GraphDB):
 
         def merge_results(doc: Json) -> Optional[Json]:
             rendered = render_prop(doc)
-            render_merge_results(doc, rendered, query)
+            if query:
+                render_merge_results(doc, rendered, query)
             return rendered
 
         return merge_results

--- a/ckcore/core/db/graphdb.py
+++ b/ckcore/core/db/graphdb.py
@@ -787,6 +787,8 @@ class ArangoGraphDB(GraphDB):
             # this index will hold all the necessary data to query for an update (index only query)
             if "update_id" not in node_idxes:
                 nodes.add_persistent_index(["_key", "update_id", "hash", "created"], sparse=False, name="update_value")
+            if "kinds" not in node_idxes:
+                nodes.add_persistent_index(["kinds[*]"], sparse=False, name="kinds")
             progress_idxes = {idx["name"]: idx for idx in progress.indexes()}
             if "parent_nodes" not in progress_idxes:
                 progress.add_persistent_index(["parent_nodes[*]"], name="parent_nodes")

--- a/ckcore/core/db/graphdb.py
+++ b/ckcore/core/db/graphdb.py
@@ -387,7 +387,7 @@ class ArangoGraphDB(GraphDB):
                     result["kinds"] = doc["kinds"]
                 return result
             else:
-                return None
+                return doc
 
         def merge_results(doc: Json) -> Optional[Json]:
             rendered = render_prop(doc)
@@ -751,10 +751,7 @@ class ArangoGraphDB(GraphDB):
         await self.delete_marked_update(batch_id)
 
     def to_query(self, query_model: QueryModel, with_edges: bool = False) -> Tuple[str, Json]:
-        # TODO: remove print
-        result = arango_query.to_query(self, query_model, with_edges)
-        # print(f"\n------\n{result[0]}\n-------\n")
-        return result
+        return arango_query.to_query(self, query_model, with_edges)
 
     async def insert_genesis_data(self) -> None:
         root_data = {"kind": "graph_root", "name": "root"}

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -263,12 +263,20 @@ class MergeQuery(Term):
     name: str
     query: Query
 
+    def __str__(self) -> str:
+        return f"{self.name}: {self.query}"
+
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
 class MergeTerm(Term):
     pre_filter: Term
     merge: List[MergeQuery]
     post_filter: Optional[Term] = None
+
+    def __str__(self) -> str:
+        merge = ", ".join(str(q) for q in self.merge)
+        post = " " + str(self.post_filter) if self.post_filter else ""
+        return f"{self.pre_filter} {{{merge}}}{post}"
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -263,6 +263,7 @@ class FunctionTerm(Term):
 class MergeQuery(Term):
     name: str
     query: Query
+    only_first: bool = True
 
     def __str__(self) -> str:
         return f"{self.name}: {self.query}"
@@ -494,8 +495,8 @@ class Query:
         return {mt.name for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge}
 
     @cached_property
-    def merge_query_by_name(self) -> Dict[str, Query]:
-        return {mt.name: mt.query for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge}
+    def merge_query_by_name(self) -> List[MergeQuery]:
+        return [mt for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge]
 
     def filter(self, term: Union[str, Term], *terms: Union[str, Term]) -> Query:
         res = Query.mk_term(term, *terms)

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -4,6 +4,7 @@ import abc
 import json
 from dataclasses import dataclass, field, replace
 from functools import reduce
+from backports.cached_property import cached_property
 from typing import Mapping, Union, Optional, Any, ClassVar, Dict, List, Tuple, Callable, Set
 
 from jsons import set_deserializer
@@ -488,9 +489,13 @@ class Query:
         parts = " ".join(str(a) for a in reversed(self.parts))
         return f"{aggregate}{preamble}{colon}{parts}"
 
-    @property
+    @cached_property
     def merge_names(self) -> Set[str]:
         return {mt.name for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge}
+
+    @cached_property
+    def merge_query_by_name(self) -> Dict[str, Query]:
+        return {mt.name: mt.query for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge}
 
     def filter(self, term: Union[str, Term], *terms: Union[str, Term]) -> Query:
         res = Query.mk_term(term, *terms)

--- a/ckcore/core/query/query_parser.py
+++ b/ckcore/core/query/query_parser.py
@@ -129,12 +129,17 @@ simple_term_p = (lparen_p >> combined_term << rparen_p) | leaf_term_p
 filter_term_parser = combined_term | simple_term_p
 
 
+square_brackets_p = lexeme(string("[]"))
+
+
 @make_parser
 def merge_query_parser() -> Parser:
     name = yield literal_p
+    is_array = yield square_brackets_p.optional()
+
     yield colon_p
     query = yield query_parser
-    return MergeQuery(name, query)
+    return MergeQuery(name, query, not (query.aggregate or is_array))
 
 
 @make_parser

--- a/ckcore/core/query/query_parser.py
+++ b/ckcore/core/query/query_parser.py
@@ -32,6 +32,8 @@ from core.parse_util import (
     double_quote_dp,
     l_curly_dp,
     r_curly_dp,
+    l_curly_p,
+    r_curly_p,
 )
 from core.query.model import (
     Predicate,
@@ -53,6 +55,8 @@ from core.query.model import (
     AggregateVariableName,
     AggregateVariableCombined,
     NotTerm,
+    MergeTerm,
+    MergeQuery,
 )
 
 operation_p = (
@@ -122,7 +126,34 @@ def combined_term() -> Parser:
 simple_term_p = (lparen_p >> combined_term << rparen_p) | leaf_term_p
 
 # This can parse a complete term
-term_parser = combined_term | simple_term_p
+filter_term_parser = combined_term | simple_term_p
+
+
+@make_parser
+def merge_query_parser() -> Parser:
+    name = yield literal_p
+    yield colon_p
+    query = yield query_parser
+    return MergeQuery(name, query)
+
+
+@make_parser
+def merge_parser() -> Parser:
+    yield l_curly_p
+    queries = yield merge_query_parser.sep_by(comma_p, min=1)
+    yield r_curly_p
+    return queries
+
+
+@make_parser
+def term_parser() -> Parser:
+    filter_term = yield filter_term_parser
+    merge = yield merge_parser.optional()
+    if merge:
+        post_filter = yield filter_term_parser.optional()
+        return MergeTerm(filter_term, merge, post_filter)
+    else:
+        return filter_term
 
 
 @make_parser
@@ -179,7 +210,7 @@ def with_clause_parser() -> Parser:
     with_filter = yield len_empty | len_any | with_count_parser
     yield comma_p
     nav = yield navigation_parser
-    term = yield term_parser.optional()
+    term = yield filter_term_parser.optional()
     with_clause = yield with_clause_parser.optional()
     yield rparen_p
     assert 0 <= nav.start <= 1, "with traversal need to start from 0 or 1"
@@ -212,13 +243,14 @@ limit_parser = limit_p + space_dp >> integer_dp
 
 @make_parser
 def part_parser() -> Parser:
-    term = yield term_parser
+    term = yield term_parser.optional()
     yield whitespace
     with_clause = yield with_clause_parser.optional()
     tag = yield tag_parser
     sort = yield sort_parser.optional()
     limit = yield limit_parser.optional()
-    nav = yield navigation_parser.optional()
+    nav = yield navigation_parser.optional() if term or sort or limit else navigation_parser
+    term = term if term else AllTerm()
     return Part(term, tag, with_clause, sort if sort else [], limit, nav)
 
 

--- a/ckcore/core/util.py
+++ b/ckcore/core/util.py
@@ -23,6 +23,7 @@ from typing import (
     Tuple,
     cast,
     AsyncIterator,
+    Iterator,
 )
 
 from dateutil.parser import isoparse
@@ -38,6 +39,10 @@ AnyR = TypeVar("AnyR")
 
 def identity(o: Any) -> Any:
     return o
+
+
+def count_iterator(start: int = 0) -> Iterator[int]:
+    return iter(range(start, sys.maxsize))
 
 
 def freeze(d: Dict[AnyT, AnyR]) -> Dict[AnyT, AnyR]:

--- a/ckcore/requirements.txt
+++ b/ckcore/requirements.txt
@@ -17,3 +17,5 @@ frozendict==2.0.7
 PyYAML==6.0
 cklib==2.0.0a9
 jq==1.2.1
+# available in python 3.8
+backports.cached-property==1.0.1

--- a/ckcore/tests/core/db/graphdb_test.py
+++ b/ckcore/tests/core/db/graphdb_test.py
@@ -405,14 +405,21 @@ async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model
 @pytest.mark.asyncio
 async def test_query_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
     q = parse_query(
-        "is(foo) --> is(bla) { parent: <--, child: -->, walk: <-- -->, agg: aggregate(sum(1) as count): <-[0:]- }"
+        "is(foo) --> is(bla) { "
+        "parents[]: <-[1:]-, "
+        "child: -->, "
+        "walk: <-- -->, "
+        "agg: aggregate(sum(1) as count): <-[0:]- "
+        "}"
     )
     async with await filled_graph_db.query_list(QueryModel(q, foo_model), with_count=True) as cursor:
         assert cursor.count() == 100
         async for bla in cursor:
             b = AccessJson(bla)
             assert b.reported.kind == "bla"
-            assert b.parent.reported.kind == "foo"
+            assert len(b.parents) == 4
+            for parent in b.parents:
+                assert parent.reported.kind == "foo"
             assert b.walk.reported.kind == "bla"
             assert b.child == AccessNone()
             assert b.agg == [{"count": 5}]

--- a/ckcore/tests/core/db/graphdb_test.py
+++ b/ckcore/tests/core/db/graphdb_test.py
@@ -19,7 +19,7 @@ from core.model.adjust_node import NoAdjust
 from core.model.graph_access import GraphAccess, EdgeType, Section
 from core.model.model import Model, ComplexKind, Property, Kind, SyntheticProperty
 from core.model.typed_model import to_js, from_js
-from core.query.model import Query, P, Navigation, MergeTerm, MergeQuery, AllTerm
+from core.query.model import Query, P, Navigation
 from core.query.query_parser import parse_query
 from core.types import JsonElement
 from core.util import AccessJson, utc, value_in_path, AccessNone
@@ -404,24 +404,18 @@ async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model
 
 @pytest.mark.asyncio
 async def test_query_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
-    next_foo = Query.by(AllTerm()).traverse_in(until=Navigation.Max).filter("foo")
-    parent = Query.by(AllTerm()).traverse_in()
-    child = Query.by(AllTerm()).traverse_out()
-    query = Query.by(
-        MergeTerm(
-            Query.mk_term("bla"),
-            [MergeQuery("foo123", next_foo), MergeQuery("parent", parent), MergeQuery("child", child)],
-            Query.mk_term("bla"),
-        )
+    q = parse_query(
+        "is(foo) --> is(bla) { parent: <--, child: -->, walk: <-- -->, agg: aggregate(sum(1) as count): <-[0:]- }"
     )
-    async with await filled_graph_db.query_list(QueryModel(query, foo_model), with_count=True) as cursor:
+    async with await filled_graph_db.query_list(QueryModel(q, foo_model), with_count=True) as cursor:
         assert cursor.count() == 100
         async for bla in cursor:
             b = AccessJson(bla)
             assert b.reported.kind == "bla"
-            assert b.foo123.reported.kind == "foo"
             assert b.parent.reported.kind == "foo"
+            assert b.walk.reported.kind == "bla"
             assert b.child == AccessNone()
+            assert b.agg == [{"count": 5}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds support for subqueries.
Subqueries are queries executed for every matching element. 
The result of this subquery will be added to the original element.

Example:
```
is(aws_ec2_instance) {region: <-[0:]- is(region), account: <-[0:]- is(account), cloud: <-[0:]- is(cloud)}  
```

This query will match all aws_ec2_instances.
The subqueries now define to add region, account and cloud by executing the related subqueries on every element.
The resulting json element will look like this:
```
[
  {
    id: ".."
    reported: {..}
    desired: {..}
    metadata: { ..}
    cloud: { id: "..", reported: {..}, desired:{..}, metadata:{..}} 
    account: { id: "..", reported: {..}, desired:{..}, metadata:{..}} 
    region: { id: "..", reported: {..}, desired:{..}, metadata:{..}} 
  },
 .
 .
]
```
