### PR TITLE
[ckcore] Add support for array modifiers

### DIFF
--- a/ckcore/core/db/arango_query.py
+++ b/ckcore/core/db/arango_query.py
@@ -111,8 +111,8 @@ def query_string(
         path = p.name
 
         # handle that property is an array
-        if "array" in p.args:
-            arr_filter = p.args["filter"] if "filter" in p.args else "any"
+        if "filter" in p.args:
+            arr_filter = p.args["filter"]
             extra = f" {arr_filter} "
             path = f"{p.name}[]"
         elif "[*]" in p.name:

--- a/ckcore/core/db/arangodb_functions.py
+++ b/ckcore/core/db/arangodb_functions.py
@@ -37,17 +37,21 @@ def in_subnet(cursor: str, bind_vars: Json, fn: FunctionTerm, model: QueryModel)
 
 
 def has_key(cursor: str, bind_vars: Json, fn: FunctionTerm, model: QueryModel) -> str:
-    for arg in fn.args:
-        assert isinstance(arg, str), f"Argument must be string, but got: {arg}"
+    assert (
+        len(fn.args) == 1
+    ), "has_key(path.to.property, name_of_prop) or has_key(path.to.property, [name_of_prop_a, name_of_prop_b])"
+    args = [fn.args[0]] if isinstance(fn.args[0], str) else fn.args[0]
+    for arg in args:
+        assert isinstance(arg, str), f"has_key: argument must be string, but got: {arg}"
     section_dot = f"{model.query_section}." if model.query_section else ""
     prop = f"fn{len(bind_vars)}"
-    if len(fn.args) == 0:
+    if len(args) == 0:
         return "true"
-    elif len(fn.args) == 1:
+    elif len(args) == 1:
         bind_vars[prop] = fn.args[0]
         return f"HAS({cursor}.{section_dot}{fn.property_path}, @{prop})"
     else:
-        bind_vars[prop] = fn.args
+        bind_vars[prop] = args
         return f"@{prop} ALL IN ATTRIBUTES({cursor}.{section_dot}{fn.property_path}, true)"
 
 

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -102,13 +102,13 @@ class PArray:
         self.name = name
 
     def for_any(self) -> P:
-        return P(self.name, array=True, filter="any")
+        return P(self.name, filter="any")
 
     def for_none(self) -> P:
-        return P(self.name, array=True, filter="none")
+        return P(self.name, filter="none")
 
     def for_all(self) -> P:
-        return P(self.name, array=True, filter="all")
+        return P(self.name, filter="all")
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
@@ -210,7 +210,8 @@ class Predicate(Term):
     args: Mapping[str, Any]
 
     def __str__(self) -> str:
-        return f"{self.name} {self.op} {self.value_str_rep(self.value)}"
+        modifier = f'{self.args["filter"]} ' if "filter" in self.args else ""
+        return f"{self.name} {modifier}{self.op} {self.value_str_rep(self.value)}"
 
     @staticmethod
     def value_str_rep(value: Any) -> str:

--- a/ckcore/core/query/query_parser.py
+++ b/ckcore/core/query/query_parser.py
@@ -67,7 +67,9 @@ operation_p = (
     | lexeme(string("~")).result("=~")
 )
 
-function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change"]])
+array_modifier_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["all", "any", "none"]])
+
+function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change", "has_key"]])
 
 
 preamble_prop_p = reduce(
@@ -78,9 +80,11 @@ preamble_prop_p = reduce(
 @make_parser
 def predicate_term() -> Parser:
     name = yield variable_p
+    modifier = yield array_modifier_p.optional()
+    opts = {"filter": modifier} if modifier else {}
     op = yield operation_p
     value = yield json_value_p
-    return Predicate(name, op, value, {})
+    return Predicate(name, op, value, opts)
 
 
 @make_parser

--- a/ckcore/tests/core/db/arangodb_functions_test.py
+++ b/ckcore/tests/core/db/arangodb_functions_test.py
@@ -21,7 +21,7 @@ def test_ip_range() -> None:
 def test_has_key() -> None:
     bind_vars: Json = {}
     model = QueryModel(Query.by("foo"), Model.empty(), "reported")
-    result = has_key("crs", bind_vars, FunctionTerm("has_key", "foo.bla", ["a", "b", "c"]), model)
+    result = has_key("crs", bind_vars, FunctionTerm("has_key", "foo.bla", [["a", "b", "c"]]), model)
     assert result == "@fn0 ALL IN ATTRIBUTES(crs.reported.foo.bla, true)"
     assert bind_vars["fn0"] == ["a", "b", "c"]
     bind_vars2: Json = {}

--- a/ckcore/tests/core/db/arangodb_functions_test.py
+++ b/ckcore/tests/core/db/arangodb_functions_test.py
@@ -1,4 +1,4 @@
-from core.db.arangodb_functions import in_subnet, has_desired_change
+from core.db.arangodb_functions import in_subnet, has_desired_change, has_key
 from core.db.model import QueryModel
 from core.model.model import Model
 from core.query.model import FunctionTerm, Query, IsTerm
@@ -16,3 +16,15 @@ def test_ip_range() -> None:
     result = in_subnet("crs", bind_vars, FunctionTerm("in_subnet", "foo.bla", ["192.168.1.0/24"]), model)
     assert result == "BIT_AND(IPV4_TO_NUMBER(crs.reported.foo.bla), 4294967040) == @0"
     assert bind_vars["0"] == 3232235776
+
+
+def test_has_key() -> None:
+    bind_vars: Json = {}
+    model = QueryModel(Query.by("foo"), Model.empty(), "reported")
+    result = has_key("crs", bind_vars, FunctionTerm("has_key", "foo.bla", ["a", "b", "c"]), model)
+    assert result == "@fn0 ALL IN ATTRIBUTES(crs.reported.foo.bla, true)"
+    assert bind_vars["fn0"] == ["a", "b", "c"]
+    bind_vars2: Json = {}
+    result = has_key("crs", bind_vars2, FunctionTerm("has_key", "foo.bla", ["a"]), model)
+    assert result == "HAS(crs.reported.foo.bla, @fn0)"
+    assert bind_vars2["fn0"] == "a"

--- a/ckcore/tests/core/query/query_parser_test.py
+++ b/ckcore/tests/core/query/query_parser_test.py
@@ -73,8 +73,12 @@ def test_parse_predicate() -> None:
 
 
 def test_parse_predicate_array() -> None:
-    # TODO: array params are not working
     assert_round_trip(predicate_term, P.array("mem").for_any() < 23)
+    assert_round_trip(predicate_term, P.array("mem").for_all() >= 23)
+    assert_round_trip(predicate_term, P.array("mem").for_none().matches("foo.*"))
+    assert_round_trip(predicate_term, P.array("num").for_any().is_in([1, 2, 5]))
+    assert_round_trip(predicate_term, P.array("num").for_all().is_in([1, 2, 5]))
+    assert_round_trip(predicate_term, P.array("num").for_none().is_in([1, 2, 5]))
 
 
 def test_kind() -> None:
@@ -85,6 +89,8 @@ def test_function() -> None:
     assert_round_trip(function_term, P.function("in_subnet").on("foo.bla.bar", 1, "2", True))
     assert_round_trip(function_term, P.function("in_subnet").on("foo.bla.bar", "in_subnet"))
     assert_round_trip(function_term, P.function("in_subnet").on("foo.bla.bar", "in_subnet", "1000"))
+    assert_round_trip(function_term, P.function("has_key").on("foo.bla.bar", "a", "b", "c"))
+    assert_round_trip(function_term, P.function("has_key").on("foo.bla.bar", "a"))
 
 
 def test_combined() -> None:


### PR DESCRIPTION
Support `some.array all > 23` or `some.array any < 12` or `some.array none in [1, 2, 3]`

Also add a function to test for available keys: `has_key(path.to.property, name_of_prop)` or `has_key(path.to.property, [name_of_prop_a, name_of_prop_b])` which evaluates to true, if reported.tags has all the properties named.