### PR TITLE
[ckcore] is() allows for list of kinds

### DIFF
--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -34,7 +34,7 @@ class P:
 
     @staticmethod
     def of_kind(name: str) -> Term:
-        return IsTerm(name)
+        return IsTerm([name])
 
     @staticmethod
     def function(fn: str) -> PFunction:
@@ -243,10 +243,11 @@ class IdTerm(Term):
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
 class IsTerm(Term):
-    kind: str
+    kinds: List[str]
 
     def __str__(self) -> str:
-        return f'is("{self.kind}")'
+        kinds = f"{self.kinds[0]}" if len(self.kinds) == 1 else f'[{", ".join(self.kinds)}]'
+        return f"is({kinds})"
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
@@ -688,7 +689,7 @@ class Query:
             if isinstance(t, Term):
                 return t
             elif isinstance(t, str):
-                return IsTerm(t)
+                return IsTerm([t])
             else:
                 raise AttributeError(f"Expected term or string, but got {t}")
 

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -246,7 +246,8 @@ class IsTerm(Term):
     kinds: List[str]
 
     def __str__(self) -> str:
-        kinds = f"{self.kinds[0]}" if len(self.kinds) == 1 else f'[{", ".join(self.kinds)}]'
+        kind_string = ", ".join(f'"{a}"' for a in self.kinds)
+        kinds = kind_string if len(self.kinds) == 1 else f"[{kind_string}]"
         return f"is({kinds})"
 
 

--- a/ckcore/core/query/query_parser.py
+++ b/ckcore/core/query/query_parser.py
@@ -106,7 +106,10 @@ def not_term() -> Parser:
     return NotTerm(term)
 
 
-is_term = lexeme(string("is") >> lparen_p >> (quoted_string_p | literal_p) << rparen_p).map(IsTerm)
+literal_list_comma_separated_p = (quoted_string_p | literal_p).sep_by(comma_p, min=1)
+literal_list_in_square_brackets = l_bracket_p >> literal_list_comma_separated_p << r_bracket_p
+literal_list_optional_brackets = literal_list_in_square_brackets | literal_list_comma_separated_p
+is_term = lexeme(string("is") >> lparen_p >> literal_list_optional_brackets << rparen_p).map(IsTerm)
 id_term = lexeme(string("id") >> lparen_p >> (quoted_string_p | literal_p) << rparen_p).map(IdTerm)
 match_all_term = lexeme(string("all")).map(lambda _: AllTerm())
 leaf_term_p = is_term | id_term | match_all_term | function_term | predicate_term | not_term

--- a/ckcore/tests/core/db/arangodb_functions_test.py
+++ b/ckcore/tests/core/db/arangodb_functions_test.py
@@ -12,7 +12,7 @@ def test_has_desired_change() -> None:
 
 def test_ip_range() -> None:
     bind_vars: Json = {}
-    model = QueryModel(Query.by(IsTerm("foo")), Model.empty(), "reported")
+    model = QueryModel(Query.by(IsTerm(["foo"])), Model.empty(), "reported")
     result = in_subnet("crs", bind_vars, FunctionTerm("in_subnet", "foo.bla", ["192.168.1.0/24"]), model)
     assert result == "BIT_AND(IPV4_TO_NUMBER(crs.reported.foo.bla), 4294967040) == @0"
     assert bind_vars["0"] == 3232235776

--- a/ckcore/tests/core/db/graphdb_test.py
+++ b/ckcore/tests/core/db/graphdb_test.py
@@ -338,6 +338,11 @@ async def test_query_list(filled_graph_db: ArangoGraphDB, foo_model: Model) -> N
         result = [from_js(x["reported"], Bla) async for x in gen]
         assert len(result) == 10
 
+    foos_or_blas = parse_query("is([foo, bla])")
+    async with await filled_graph_db.query_list(QueryModel(foos_or_blas, foo_model, "reported")) as gen:
+        result = [x async for x in gen]
+        assert len(result) == 113  # all documents, since there are only foos and blas
+
 
 @pytest.mark.asyncio
 async def test_query_not(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:

--- a/ckcore/tests/core/query/model_test.py
+++ b/ckcore/tests/core/query/model_test.py
@@ -57,11 +57,11 @@ def test_simple_query() -> None:
 
 def test_simplify() -> None:
     # some_criteria | all => all
-    assert str((IsTerm("test") | AllTerm()).simplify()) == "all"
+    assert str((IsTerm(["test"]) | AllTerm()).simplify()) == "all"
     # some_criteria & all => some_criteria
-    assert str((IsTerm("test") & AllTerm()).simplify()) == 'is("test")'
+    assert str((IsTerm(["test"]) & AllTerm()).simplify()) == 'is("test")'
     # also works in nested setup
-    q = Query.by(AllTerm() & ((P("test") == True) & (IsTerm("test") | AllTerm()))).simplify()
+    q = Query.by(AllTerm() & ((P("test") == True) & (IsTerm(["test"]) | AllTerm()))).simplify()
     assert (str(q)) == "test == true"
 
 
@@ -87,10 +87,10 @@ def test_combine() -> None:
     assert str(query3) == 'test == true --> is("boo") --> ((is("bar") and is("foo")) and is("bla"))'
     query4 = Query.by("a").with_limit(10).combine(Query.by("b").with_limit(2))
     assert query4.current_part.limit == 2  # minimum is taken
-    with pytest.raises(AttributeError) as ae:
+    with pytest.raises(AttributeError):
         # can not combine 2 aggregations
         parse_query("aggregate(sum(1)): is(a)").combine(parse_query("aggregate(sum(1)): is(a)"))
-    with pytest.raises(AttributeError) as ae:
+    with pytest.raises(AttributeError):
         # can not combine 2 with statements
         parse_query("is(foo) with(empty, -->)").combine(parse_query("is(bla) with(empty, -->)"))
 

--- a/ckcore/tests/core/query/query_parser_test.py
+++ b/ckcore/tests/core/query/query_parser_test.py
@@ -48,8 +48,12 @@ from core.query.query_parser import (
 
 
 def test_parse_is_term() -> None:
-    assert is_term.parse('is("test")') == IsTerm("test")
-    assert is_term.parse("is(test)") == IsTerm("test")
+    assert is_term.parse("is(test)") == IsTerm(["test"])
+    assert is_term.parse("is(a, b, c)") == IsTerm(["a", "b", "c"])
+    assert is_term.parse("is([a,b,c])") == IsTerm(["a", "b", "c"])
+    assert is_term.parse("is(volume, instance)") == IsTerm(["volume", "instance"])
+    assert_round_trip(is_term, IsTerm(["volume", "instance"]))
+    assert_round_trip(is_term, IsTerm(["test"]))
 
 
 def test_parse_id_term() -> None:


### PR DESCRIPTION
`is(volume)` matches all resources of type volume

`is([volume, instance])` matches all resources of type volume or of type instance