### PR TITLE
[bump] Define arangodb 3.8.3 as dependency

### DIFF
--- a/.github/workflows/test_ckcore.yml
+++ b/.github/workflows/test_ckcore.yml
@@ -14,7 +14,7 @@ jobs:
                 working-directory: ./ckcore
         services:
             arangodb:
-                image: arangodb:3.8
+                image: arangodb:3.8.3
                 env:
                     ARANGO_ROOT_PASSWORD: root
                 ports:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TESTS
 ARG SOURCE_COMMIT
 ARG PYTHON_VERSION=3.10.0
 ARG PYPY_VERSION=7.3.7
-ARG ARANGODB_VERSION=3.8.1
+ARG ARANGODB_VERSION=3.8.3
 ARG PROMETHEUS_VERSION=2.30.1
 
 ENV PATH=/usr/local/db/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/ckcore/core/db/async_arangodb.py
+++ b/ckcore/core/db/async_arangodb.py
@@ -158,9 +158,6 @@ class AsyncArangoDBBase:
         skip_inaccessible_cols: Optional[bool] = None,
         max_runtime: Optional[Number] = None,
     ) -> AsyncCursorContext:
-        # TODO: remove the 2 lines once this fix: https://github.com/arangodb/arangodb/pull/14801 is released
-        opt = ["-reduce-extraction-to-projection"]
-        optimizer_rules = list(optimizer_rules) + opt if optimizer_rules else opt
         cursor = await run_async(
             self.db.aql.execute,
             query,

--- a/ckcore/core/error.py
+++ b/ckcore/core/error.py
@@ -20,6 +20,12 @@ class ServerError(Exception):
     """
 
 
+class RequiredDependencyMissingError(ServerError):
+    """
+    Required downstream system is not available or not available in correct version.
+    """
+
+
 class DatabaseError(CoreException):
     """
     Base for all database exceptions.

--- a/docs/source/getting_started/setup_individual_components.rst
+++ b/docs/source/getting_started/setup_individual_components.rst
@@ -15,7 +15,7 @@ All the installation will take place in your home directory ``~/cloudkeeper/``. 
 Prerequisites
 *************
 
-Python >= 3.9 is required for all Cloudkeeper components. ArangoDB >= 3.8.1 is used as the ``ckcore`` graph storage.
+Python >= 3.9 is required for all Cloudkeeper components. ArangoDB >= 3.8.3 is used as the ``ckcore`` graph storage.
 Optionally the Cloudkeeper Metrics Exporter ``ckmetrics`` can be installed and its metrics pulled by the Prometheus time series database.
 This guide uses ``curl`` and ``git`` to download components.
 


### PR DESCRIPTION
Reverts workaround introduced in #254
Fixes: https://github.com/someengineering/cloudkeeper/projects/1#card-69699569