### PR TITLE
[ckcore] Rewrite query to automatically merge ancestors and/or descendants

### DIFF
--- a/ckcore/core/cli/cli.py
+++ b/ckcore/core/cli/cli.py
@@ -342,7 +342,7 @@ class CLI:
                 query = query.with_limit(size)
             else:
                 raise AttributeError(f"Do not understand: {part} of type: {class_fqn(part)}")
-        args = str(query.simplify())
+        args = str(query)
         execute_query = self.command("execute_query", args, ctx)
         return [execute_query, *additional_commands]
 

--- a/ckcore/core/model/graph_access.py
+++ b/ckcore/core/model/graph_access.py
@@ -89,6 +89,18 @@ class EdgeType:
     all = {dependency, delete}
 
 
+class Direction:
+    # Opposite direction as the edge direction.
+    inbound = "in"
+    # Same direction as the edge direction
+    outbound = "out"
+    # Ignore the direction of the edge and traverse in any direction.
+    any = "inout"
+
+    # The list of all allowed directions.
+    all = [inbound, outbound, any]
+
+
 EdgeKey = namedtuple("EdgeKey", ["from_node", "to_node", "edge_type"])
 
 

--- a/ckcore/core/model/resolve_in_graph.py
+++ b/ckcore/core/model/resolve_in_graph.py
@@ -30,6 +30,10 @@ class ResolveProp:
     # Path to write this property to
     to_path: List[str]
 
+    @property
+    def to(self) -> str:
+        return ".".join(self.to_path)
+
 
 @dataclass(frozen=True)
 class ResolveAncestor:
@@ -87,9 +91,11 @@ class GraphResolver:
         ),
     ]
 
-    resolved_ancestors = {
-        kind: ".".join(prop.to_path) for kind, prop in {a.kind: a.resolves_id() for a in to_resolve}.items() if prop
-    }
+    # dict: kind->property name to get the id in order to resolve this kind
+    resolved_ancestors = {kind: prop.to for kind, prop in {a.kind: a.resolves_id() for a in to_resolve}.items() if prop}
+
+    # set of all resolved property names
+    resolved_property_names = {prop.to for elem in to_resolve for prop in elem.resolve}
 
     count_successors = {
         # note: order is important. zone is computed first and can be reused for region -> account -> cloud etc.

--- a/ckcore/core/query/model.py
+++ b/ckcore/core/query/model.py
@@ -9,7 +9,8 @@ from typing import Mapping, Union, Optional, Any, ClassVar, Dict, List, Tuple, C
 
 from jsons import set_deserializer
 
-from core.model.graph_access import EdgeType
+from core.model.graph_access import EdgeType, Direction
+from core.model.resolve_in_graph import GraphResolver
 from core.model.typed_model import to_js_str
 from core.types import Json, JsonElement
 from core.util import combine_optional
@@ -147,15 +148,19 @@ class Term(abc.ABC):
     def not_term(self) -> NotTerm:
         return NotTerm(self)
 
-    def or_term(self, other: Term) -> CombinedTerm:
-        if not isinstance(other, Term):
-            raise AttributeError(f"Expected Term but got {other}")
+    def or_term(self, other: Term) -> Term:
+        if isinstance(self, AllTerm):
+            return self
+        elif isinstance(other, AllTerm):
+            return other
         else:
             return CombinedTerm(self, "or", other)
 
-    def and_term(self, other: Term) -> CombinedTerm:
-        if not isinstance(other, Term):
-            raise AttributeError(f"Expected Term but got {other}")
+    def and_term(self, other: Term) -> Term:
+        if isinstance(self, AllTerm):
+            return other
+        elif isinstance(other, AllTerm):
+            return self
         else:
             return CombinedTerm(self, "and", other)
 
@@ -167,24 +172,6 @@ class Term(abc.ABC):
                 return Predicate(f"{section}.{term.name}", term.op, term.value, term.args)
             elif isinstance(term, FunctionTerm):
                 return FunctionTerm(term.fn, f"{section}.{term.property_path}", term.args)
-            else:
-                return term
-
-        return walk(self)
-
-    def simplify(self) -> Term:
-        def walk(term: Term) -> Term:
-            if isinstance(term, CombinedTerm):
-                left = walk(term.left)
-                right = walk(term.right)
-                left_all = isinstance(left, AllTerm)
-                right_all = isinstance(right, AllTerm)
-                if left_all or right_all:
-                    if (left_all and term.op == "and") or (right_all and term.op == "or"):
-                        return right
-                    elif (right_all and term.op == "and") or (left_all and term.op == "or"):
-                        return left
-                return CombinedTerm(left, term.op, right)
             else:
                 return term
 
@@ -316,7 +303,7 @@ class Navigation:
     start: int = 1
     until: int = 1
     edge_type: str = EdgeType.default
-    direction: str = "out"
+    direction: str = Direction.outbound
 
     def __str__(self) -> str:
         start = self.start
@@ -324,9 +311,9 @@ class Navigation:
         until_str = "" if until == Navigation.Max else until
         depth = ("" if start == 1 else f"[{start}]") if start == until else f"[{start}:{until_str}]"
         nav = depth if self.edge_type == EdgeType.default else f"{self.edge_type}{depth}"
-        if self.direction == "out":
+        if self.direction == Direction.outbound:
             return f"-{nav}->"
-        elif self.direction == "in":
+        elif self.direction == Direction.inbound:
             return f"<-{nav}-"
         else:
             return f"<-{nav}->"
@@ -390,6 +377,122 @@ class Part:
             with_clause=self.with_clause.on_section(section) if self.with_clause else None,
             sort=[sort.on_section(section) for sort in self.sort],
         )
+
+    def rewrite_for_ancestors_descendants(self) -> Part:
+        """
+        This function rewrites this part if predicates in the "magic" sections ancestors or descendants are used.
+        Intention: a merge is performed by traversing the graph either inbound (ancestors) or outbound (descendants).
+
+        The ancestors or descendants predicate has this form and will create a merge query:
+        ancestors.<kind>.<path.to.prop> creates a merge query: {ancestors.<kind> <-[0:]- is(<kind>)}
+        descendants.<kind>.<path.to.prop> creates a merge query: {descendants.<kind> -[0:]-> is(<kind>)}
+
+        The query is rewritten in order to create a prefilter with all terms that do not depend on the merge.
+        A MergeTerm is either created if not existent or the existing one will be extended with all merge query
+        additions. All merge relevant parts will be performed as merge term post filter.
+        Even if the query is rewritten, the logic of the query is not changed and stays the same.
+
+        :return: the rewritten part with resolved merge parts if ancestor or descendant predicates are found.
+        """
+        before_merge: Term = AllTerm()
+        after_merge: Term = AllTerm()
+
+        def is_ancestor_descendant(name: str) -> bool:
+            return name not in GraphResolver.resolved_property_names and (
+                name.startswith("ancestors.") or name.startswith("descendants.")
+            )
+
+        def has_ancestor_descendant(t: Term) -> bool:
+            if isinstance(t, Predicate) and is_ancestor_descendant(t.name):
+                return True
+            elif isinstance(t, CombinedTerm):
+                return has_ancestor_descendant(t.left) or has_ancestor_descendant(t.right)
+            elif isinstance(t, MergeTerm):
+                return has_ancestor_descendant(t.pre_filter) or (
+                    t.post_filter is not None and has_ancestor_descendant(t.post_filter)
+                )
+            elif isinstance(t, NotTerm):
+                return has_ancestor_descendant(t.term)
+            else:
+                return False
+
+        def ancestor_descendant_names(t: Term) -> List[str]:
+            if isinstance(t, Predicate) and is_ancestor_descendant(t.name):
+                return [t.name]
+            elif isinstance(t, CombinedTerm):
+                return [*ancestor_descendant_names(t.left), *ancestor_descendant_names(t.right)]
+            elif isinstance(t, MergeTerm):
+                result = ancestor_descendant_names(t.pre_filter)
+                if t.post_filter:
+                    result.extend(ancestor_descendant_names(t.post_filter))
+                return result
+            elif isinstance(t, NotTerm):
+                return ancestor_descendant_names(t.term)
+            else:
+                return []
+
+        def walk_term(term: Term) -> None:
+            # precondition: this method is only called with a term that has ancestor/descendant
+            nonlocal before_merge
+            nonlocal after_merge
+            if isinstance(term, CombinedTerm):
+                left_has_ad = has_ancestor_descendant(term.left)
+                right_has_ad = has_ancestor_descendant(term.right)
+                if term.op == "or":
+                    after_merge = after_merge & term
+                elif left_has_ad and right_has_ad:
+                    walk_term(term.left)
+                    walk_term(term.right)
+                elif left_has_ad:
+                    before_merge = before_merge & term.right
+                    walk_term(term.left)
+                elif right_has_ad:
+                    before_merge = before_merge & term.left
+                    walk_term(term.right)
+                else:
+                    raise NotImplementedError("Logic unsound. This case should not happen!")
+            elif isinstance(term, MergeTerm):
+                # in case pre- and post- filter are defined, handle it as AND combined term
+                # background: pre- and post- filter will be applied on the result
+                #             that effectively reflects an and combination.
+                #             The merge part only merges data to the existing values.
+                if term.post_filter:
+                    walk_term(CombinedTerm(term.pre_filter, "and", term.post_filter))
+                else:
+                    walk_term(term.pre_filter)
+            else:
+                after_merge = after_merge & term
+
+        def merge_query_for(name: str) -> MergeQuery:
+            try:
+                anc_dec, kind, _ = name.split(".", 2)
+                direction = Direction.inbound if anc_dec == "ancestors" else Direction.outbound
+                subquery = Query(
+                    [
+                        Part(
+                            IsTerm([kind]),
+                        ),
+                        Part(AllTerm(), navigation=Navigation(1, Navigation.Max, direction=direction)),
+                    ]
+                )
+                return MergeQuery(f"{anc_dec}.{kind}", subquery)
+            except ValueError as ex:
+                raise AttributeError(
+                    "The name of an ancestor variable has to follow the format: ancestor.<kind>.<path.to.variable>. "
+                    "The kind defines the type of the ancestor to look for.\n"
+                    "Example: ancestors.account.reported.name=test\n"
+                    "Example: descendant..reported.name=test\n"
+                ) from ex
+
+        if has_ancestor_descendant(self.term):
+            walk_term(self.term)
+            predicates = ancestor_descendant_names(after_merge)
+            existing = {a.name: a for a in (self.term.merge if isinstance(self.term, MergeTerm) else [])}
+            created = {a.name: a for a in [merge_query_for(name) for name in predicates]}
+            queries = list({**created, **existing}.values())
+            return replace(self, term=MergeTerm(before_merge, queries, after_merge))
+        else:
+            return self
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
@@ -549,15 +652,17 @@ class Query:
         return replace(self, parts=[first, *self.parts[1:]])
 
     def traverse_out(self, start: int = 1, until: int = 1, edge_type: str = EdgeType.default) -> Query:
-        return self.traverse(start, until, edge_type, "out")
+        return self.traverse(start, until, edge_type, Direction.outbound)
 
     def traverse_in(self, start: int = 1, until: int = 1, edge_type: str = EdgeType.default) -> Query:
-        return self.traverse(start, until, edge_type, "in")
+        return self.traverse(start, until, edge_type, Direction.inbound)
 
     def traverse_inout(self, start: int = 1, until: int = 1, edge_type: str = EdgeType.default) -> Query:
-        return self.traverse(start, until, edge_type, "inout")
+        return self.traverse(start, until, edge_type, Direction.any)
 
-    def traverse(self, start: int, until: int, edge_type: str = EdgeType.default, direction: str = "out") -> Query:
+    def traverse(
+        self, start: int, until: int, edge_type: str = EdgeType.default, direction: str = Direction.outbound
+    ) -> Query:
         parts = self.parts.copy()
         p0 = parts[0]
         if p0.navigation:
@@ -576,10 +681,6 @@ class Query:
     def group_by(self, group_by: List[AggregateVariable], funcs: List[AggregateFunction]) -> Query:
         aggregate = Aggregate(group_by, funcs)
         return replace(self, aggregate=aggregate)
-
-    def simplify(self) -> Query:
-        parts = [replace(part, term=part.term.simplify()) for part in self.parts]
-        return replace(self, parts=parts)
 
     def add_sort(self, name: str, order: str = SortOrder.Asc) -> Query:
         return self.__change_current_part(lambda p: replace(p, sort=[*p.sort, Sort(name, order)]))

--- a/ckcore/tests/core/query/__init__.py
+++ b/ckcore/tests/core/query/__init__.py
@@ -14,7 +14,7 @@ from hypothesis.strategies import (
     tuples,
 )
 
-from core.model.graph_access import EdgeType
+from core.model.graph_access import EdgeType, Direction
 from tests.core.hypothesis_extension import Drawer, optional
 from core.query.model import (
     IsTerm,
@@ -46,7 +46,7 @@ kind = sampled_from(["bucket", "volume", "certificate", "cloud", "database", "en
 query_operations = sampled_from(["==", ">=", "<=", ">", "<"])
 query_values = sampled_from(["test", 23, True, False, None])
 combine_term = sampled_from(["and", "or"])
-edge_direction = sampled_from(["in", "out", "inout"])
+edge_direction = sampled_from(Direction.all)
 edge_type = sampled_from(list(EdgeType.all))
 sort_order = sampled_from([SortOrder.Asc, SortOrder.Desc])
 aggregate_functions = sampled_from(["sum", "count", "min", "max", "avg"])

--- a/ckcore/tests/core/query/model_test.py
+++ b/ckcore/tests/core/query/model_test.py
@@ -57,11 +57,11 @@ def test_simple_query() -> None:
 
 def test_simplify() -> None:
     # some_criteria | all => all
-    assert str((IsTerm(["test"]) | AllTerm()).simplify()) == "all"
+    assert str((IsTerm(["test"]) | AllTerm())) == "all"
     # some_criteria & all => some_criteria
-    assert str((IsTerm(["test"]) & AllTerm()).simplify()) == 'is("test")'
+    assert str((IsTerm(["test"]) & AllTerm())) == 'is("test")'
     # also works in nested setup
-    q = Query.by(AllTerm() & ((P("test") == True) & (IsTerm(["test"]) | AllTerm()))).simplify()
+    q = Query.by(AllTerm() & ((P("test") == True) & (IsTerm(["test"]) | AllTerm())))
     assert (str(q)) == "test == true"
 
 
@@ -102,3 +102,52 @@ def test_on_section() -> None:
         "(r.a < 1 and r.b == 23) sort r.foo asc"
     )
     assert str(parse_query(query).on_section("r")) == on_section
+
+
+def test_rewrite_ancestors_descendants() -> None:
+    # a query without ancestor/descendants is not changed
+    assert str(parse_query("(a<1 and b>1) or c==3")) == "((a < 1 and b > 1) or c == 3)"
+    # a query with resolved ancestor is not changed
+    assert (
+        str(parse_query('a<1 and ancestors.cloud.reported.name=="test"'))
+        == '(a < 1 and ancestors.cloud.reported.name == "test")'
+    )
+    # a query with unknown ancestor creates a merge query
+    assert (
+        str(parse_query('a<1 and ancestors.cloud.reported.kind=="cloud"'))
+        == 'a < 1 {ancestors.cloud: all <-[1:]- is("cloud")} ancestors.cloud.reported.kind == "cloud"'
+    )
+    # multiple ancestors are put into one merge query
+    assert (
+        str(parse_query('a<1 and ancestors.cloud.reported.kind=="c" and ancestors.account.reported.kind=="a"'))
+        == 'a < 1 {ancestors.cloud: all <-[1:]- is("cloud"), ancestors.account: all <-[1:]- is("account")} '
+        '(ancestors.cloud.reported.kind == "c" and ancestors.account.reported.kind == "a")'
+    )
+    # existing merge queries are preserved
+    assert (
+        str(parse_query('a<1 {children[]: --> all} ancestors.cloud.reported.kind=="c"'))
+        == 'a < 1 {ancestors.cloud: all <-[1:]- is("cloud"), children[]: all --> all} '
+        'ancestors.cloud.reported.kind == "c"'
+    )
+    # predefined merge queries are preserved
+    assert (
+        str(parse_query('a<1 {ancestors.cloud: --> is(region)} ancestors.cloud.reported.kind=="c"'))
+        == 'a < 1 {ancestors.cloud: all --> is("region")} ancestors.cloud.reported.kind == "c"'
+    )
+    # This is an example of a horrible query: all entries have to be merged, before a filter can be applied
+    assert (
+        str(parse_query("(a<1 and b>1) or ancestors.d.c<1"))
+        == 'all {ancestors.d: all <-[1:]- is("d")} ((a < 1 and b > 1) or ancestors.d.c < 1)'
+    )
+    # Test some special examples
+    assert (
+        str(parse_query("ancestors.d.c<1 and (a<1 or b>1) and ancestors.a.b>1"))
+        == '(a < 1 or b > 1) {ancestors.d: all <-[1:]- is("d"), ancestors.a: all <-[1:]- is("a")} '
+        "(ancestors.d.c < 1 and ancestors.a.b > 1)"
+    )
+    # the independent query terms are always in the pre-filter before the merge is applied
+    assert (
+        str(parse_query("(a<1 and b>1) and (c<d or ancestors.d.c<1)"))
+        == str(parse_query("(c<d or ancestors.d.c<1) and (a<1 and b>1)"))
+        == '(a < 1 and b > 1) {ancestors.d: all <-[1:]- is("d")} (c < "d" or ancestors.d.c < 1)'
+    )

--- a/ckcore/tests/core/query/model_test.py
+++ b/ckcore/tests/core/query/model_test.py
@@ -151,3 +151,9 @@ def test_rewrite_ancestors_descendants() -> None:
         == str(parse_query("(c<d or ancestors.d.c<1) and (a<1 and b>1)"))
         == '(a < 1 and b > 1) {ancestors.d: all <-[1:]- is("d")} (c < "d" or ancestors.d.c < 1)'
     )
+    # multiple filters to the same kind only create one merge query
+    assert (
+        str(parse_query("ancestors.a.b<1 and ancestors.a.c>1 and ancestors.a.d=3 and ancestors.b.c>1 and a==1"))
+        == 'a == 1 {ancestors.a: all <-[1:]- is("a"), ancestors.b: all <-[1:]- is("b")} '
+        "(((ancestors.a.b < 1 and ancestors.a.c > 1) and ancestors.a.d == 3) and ancestors.b.c > 1)"
+    )

--- a/ckcore/tests/core/query/query_parser_test.py
+++ b/ckcore/tests/core/query/query_parser_test.py
@@ -26,7 +26,7 @@ from core.query.model import (
     MergeTerm,
     MergeQuery,
 )
-from core.model.graph_access import EdgeType
+from core.model.graph_access import EdgeType, Direction
 from parsy import Parser
 from core.query.query_parser import (
     predicate_term,
@@ -139,7 +139,7 @@ def test_navigation() -> None:
     for edge_type in EdgeType.all:
         # the default edge type is not rendered, so we set it explicitly to make the mapping homogeneous
         fn = make_default if edge_type == EdgeType.default else None
-        for direction in ["in", "out", "inout"]:
+        for direction in Direction.all:
             for start, until in [(0, 0), (1, 1), (5, 5), (1, 10), (1, Navigation.Max), (10, Navigation.Max)]:
                 assert_round_trip(navigation_parser, Navigation(start, until, edge_type, direction), fn)
 


### PR DESCRIPTION
This PR brings a change to the query language which introduces 2 "magic" sections: ancestors and descendants.
In order to merge and filter data of properties coming from a node which is connected to the current selected node,
it is now as easy as write: `ancestors.<kind>.path.to.property <op> <value>`. This predicate will be translated into a merge query which will merge the current node with the ancestor node of given kind. The path that is defined will be available after the merge and can be used to filter the result.

Example:
```
> query is(volume) and ancestors.volume_type.reported.volume_type=pd-standard
```
This query will select all `volume`s. All matching instances get merged with the relevant ancestor of kind `volume_type` and filtered by the reported property `volume_type`.
The result will emit a list of volumes with the related volume_type merged with every node.


