### PR TITLE
[cklib] Add `csr_to_bytes()` to x509 functions

### DIFF
--- a/cklib/cklib/x509.py
+++ b/cklib/cklib/x509.py
@@ -148,7 +148,8 @@ def sign_csr(
 
 
 def write_csr_to_file(csr: CertificateSigningRequest, csr_path: str) -> None:
-    return write_cert_to_file(csr, csr_path)
+    with open(csr_path, "wb") as f:
+        f.write(csr_to_bytes(csr))
 
 
 def write_cert_to_file(cert: Certificate, cert_path: str) -> None:
@@ -179,6 +180,10 @@ def key_to_bytes(
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         **kwargs,
     )
+
+
+def csr_to_bytes(csr: CertificateSigningRequest) -> bytes:
+    return cert_to_bytes(csr)
 
 
 def cert_to_bytes(cert: Certificate) -> bytes:


### PR DESCRIPTION
For completeness this adds `csr_to_bytes()` as an alias to `cert_to_bytes()`