### PR TITLE
[ckcore] Introduce query cost explanation

### DIFF
--- a/ckcore/core/cli/cli.py
+++ b/ckcore/core/cli/cli.py
@@ -339,7 +339,9 @@ class CLI:
                 assert query.aggregate is None, "Can not combine aggregate and count!"
                 group_by = [AggregateVariable(AggregateVariableName(arg), "name")] if arg else []
                 aggregate = Aggregate(group_by, [AggregateFunction("sum", 1, [], "count")])
-                additional_commands.append(self.command("aggregate_to_count", None, ctx))
+                # If the query should be explained, we want the output as is
+                if "explain" not in parsed_options:
+                    additional_commands.append(self.command("aggregate_to_count", None, ctx))
                 query = replace(query, aggregate=aggregate)
                 query = query.add_sort("count")
             elif isinstance(part, HeadCommand):

--- a/ckcore/core/db/__init__.py
+++ b/ckcore/core/db/__init__.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 
 
 @dataclass
@@ -7,3 +8,25 @@ class SystemData:
     system_id: str
     created_at: datetime
     db_version: int
+
+
+class EstimatedQueryCostRating(Enum):
+    simple = 1
+    complex = 2
+    bad = 3
+
+
+@dataclass
+class EstimatedQueryCost:
+    # Absolute number that shows the cost of this query. See rating for an interpreted number.
+    estimated_cost: int
+    # This is the estimated number of items returned for this query.
+    # Please note: it is computed based on query statistics and heuristics and does not reflect the real number.
+    estimated_nr_items: int
+    # This is the number of available nodes in the graph.
+    available_nr_items: int
+    # Indicates, if a full collection scan is required.
+    # This means, that the query does not take advantage of any indexes!
+    full_collection_scan: bool
+    # The rating of this query
+    rating: EstimatedQueryCostRating

--- a/ckcore/core/db/async_arangodb.py
+++ b/ckcore/core/db/async_arangodb.py
@@ -352,6 +352,9 @@ class AsyncArangoDBBase:
     async def all(self, collection: str, skip: Optional[int] = None, limit: Optional[int] = None) -> Cursor:
         return await run_async(self.db.collection(collection).all, skip, limit)
 
+    async def count(self, collection: str) -> int:
+        return await run_async(self.db.collection(collection).count)  # type: ignore
+
     @timed("arango", "insert_many")
     async def insert_many(
         self,

--- a/ckcore/core/static/api-doc.yaml
+++ b/ckcore/core/static/api-doc.yaml
@@ -996,7 +996,7 @@ paths:
                 Example: reported.age>23 and desired.clean==true and metadata.version==2
 
             tags:
-                - debug
+                - graph_query
             parameters:
                 -   name: graph_id
                     in: path
@@ -1017,8 +1017,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: object
-                                additionalProperties: true
+                                $ref: "#/components/schemas/EstimatedQueryCost"
     /graph/{graph_id}/search:
         get:
             summary: "Search the graph"
@@ -1533,7 +1532,7 @@ paths:
             summary: "Explain the query execution plan"
 
             tags:
-                - debug
+                - graph_query
             parameters:
                 -   name: graph_id
                     in: path
@@ -1564,8 +1563,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: object
-                                additionalProperties: true
+                                $ref: "#/components/schemas/EstimatedQueryCost"
     # endregion
 
     # region events
@@ -2651,3 +2649,37 @@ components:
                     type: object
                     description: "All binding variables for this query"
                     additionalProperties: true
+
+        EstimatedQueryCost:
+            type: object
+            description: "The estimated cost of a query"
+            properties:
+                estimated_cost:
+                    type: integer
+                    description: Absolute number that shows the cost of this query. See rating for an interpreted number.
+                estimated_nr_items:
+                    type: integer
+                    description: |
+                        This is the estimated number of items returned for this query.
+                        Please note: it is computed based on query statistics and heuristics and does not reflect the real number.
+                available_nr_items:
+                    type: integer
+                    description: This is the number of available nodes in the graph.
+                full_collection_scan:
+                    type: boolean
+                    description: |
+                        Indicates, if a full collection scan is required.
+                        This means, that the query does not take advantage of any indexes!
+                rating:
+                    type: string
+                    description: |
+                        The rating of this query.
+                        A simple query is usually fine.
+                        A complex query might be acceptable in certain cases. Maybe an index can be used to make this query simple?
+                        A bad query is usually something where an index is missing or the query has to be rewritten.
+                    enum:
+                        - simple
+                        - complex
+                        - bad
+
+

--- a/ckcore/core/web/api.py
+++ b/ckcore/core/web/api.py
@@ -634,7 +634,7 @@ class Api:
         q = await self.query_parser.parse_query(query_string)
         m = await self.model_handler.load_model()
         result = await graph_db.explain(QueryModel(q, m, section))
-        return web.json_response(result)
+        return web.json_response(to_js(result))
 
     async def search_graph(self, request: Request) -> StreamResponse:
         if not feature.DB_SEARCH:

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -123,6 +123,9 @@ async def test_query_source(cli: CLI) -> None:
     # = 3 elements
     assert len(result3[0]) == 3
 
+    result4 = await cli.execute_cli_command("query --explain --include-edges is(graph_root) -[0:1]->", stream.list)
+    assert result4[0][0]["rating"] == "simple"
+
 
 @pytest.mark.asyncio
 async def test_sleep_source(cli: CLI) -> None:

--- a/ckcore/tests/core/db/arango_query_test.py
+++ b/ckcore/tests/core/db/arango_query_test.py
@@ -1,8 +1,13 @@
-from core.db.arango_query import to_query
+import pytest
+
+from core.db import EstimatedQueryCost, EstimatedQueryCostRating
+from core.db.arango_query import to_query, query_cost
 from core.db.graphdb import GraphDB
 from core.db.model import QueryModel
 from core.model.model import Model
 from core.query.model import Query
+
+from core.query.query_parser import parse_query
 
 # noinspection PyUnresolvedReferences
 from tests.core.db.graphdb_test import foo_kinds, foo_model, test_db, graph_db
@@ -17,3 +22,26 @@ def test_sort_order_for_synthetic_prop(foo_model: Model, graph_db: GraphDB) -> N
     check_sort_in_query(Query.by("foo").add_sort("some.age"), "m0.some.age asc")
     check_sort_in_query(Query.by("foo").add_sort("reported.ctime"), "m0.reported.ctime asc")
     check_sort_in_query(Query.by("foo").add_sort("metadata.expired"), "m0.metadata.expired asc")
+
+
+@pytest.mark.asyncio
+async def test_query_cost(foo_model: Model, graph_db: GraphDB) -> None:
+    async def cost(query_str: str) -> EstimatedQueryCost:
+        query = parse_query(query_str)
+        return await query_cost(graph_db, QueryModel(query, foo_model), False)
+
+    c1 = await cost("aggregate(sum(1) as count):is(base) sort count asc")
+    assert c1.full_collection_scan is False
+    assert c1.rating is EstimatedQueryCostRating.simple
+
+    c2 = await cost("is(base) sort count asc")
+    assert c2.full_collection_scan is False
+    assert c2.rating is EstimatedQueryCostRating.simple
+
+    c3 = await cost("all sort reported.name asc")
+    assert c3.full_collection_scan is True
+    assert c3.rating is EstimatedQueryCostRating.complex
+
+    c4 = await cost("all {parents: <-[0:]-} sort reported.name asc")
+    assert c4.full_collection_scan is True
+    assert c4.rating is EstimatedQueryCostRating.bad


### PR DESCRIPTION
API: use the `/query/explain` endpoint to get the query cost estimate.

CLI: use `query --explain` flag to get the query cost estimate.

Fixes: #505