### PR TITLE
[ckcore] Introduce the TaskSurpassBehaviour `Wait`

### DIFF
--- a/ckcore/core/task/task_description.py
+++ b/ckcore/core/task/task_description.py
@@ -44,11 +44,14 @@ class TaskSurpassBehaviour(Enum):
     - Skip: the new task is not started and dropped.
     - Parallel: the new task is started and runs side by side with the already running instance.
     - Replace: the already running task is stopped and gets replaced by the new one.
+    - Wait: wait for the current job to finish and then execute.
+            Note: the same task description can only be enqueued once, not multiple times.
     """
 
     Skip = 1
     Parallel = 2
     Replace = 3
+    Wait = 4
 
 
 # region StepAction: what to do in one step


### PR DESCRIPTION
A TaskDescriptor can now use surpass behaviour wait.
If a task is started and there is a task with the same descriptor already running, the task is added to a starting queue. Once the existing task is finished, the next task will be started directly.

Note: There can be only one item in the waiting queue per task descriptor. If one task is already running, one already in the waiting queue and another one is triggered, the waiting queue does not change.

Fixes #172