### PR TITLE
[ckcore] Fix entrypoint.

### DIFF
--- a/ckcore/tests/core/web/api_test.py
+++ b/ckcore/tests/core/web/api_test.py
@@ -8,7 +8,7 @@ from _pytest.fixtures import fixture
 from aiohttp import ClientSession
 from arango.database import StandardDatabase
 
-from core.__main__ import main
+from core.__main__ import run
 from core.config import ConfigEntity
 from core.db import EstimatedQueryCostRating
 from core.db.model import GraphUpdate
@@ -44,7 +44,7 @@ async def core_client(
     test_db.collection("model").insert_many([{"_key": elem.fqn, **to_js(elem)} for elem in foo_kinds])
 
     process = Process(
-        target=main, args=(["--graphdb-database", "test", "--graphdb-username", "test", "--graphdb-password", "test"],)
+        target=run, args=(["--graphdb-database", "test", "--graphdb-username", "test", "--graphdb-password", "test"],)
     )
     process.start()
     ready = False


### PR DESCRIPTION
The entry point to the process as defined in setup.py does not allow to define parameters.
So `main` does not define parameters, but `run` does.
`run` is used in Integration tests to start ckcore in different configurations.