### PR TITLE
[ckcore] Unify jobs command

### DIFF
--- a/ckcore/core/__main__.py
+++ b/ckcore/core/__main__.py
@@ -17,7 +17,8 @@ from core.analytics import CoreEvent, NoEventSender
 from core.analytics.posthog import PostHogEventSender
 from core.analytics.recurrent_events import emit_recurrent_events
 from core.cli.cli import CLI
-from core.cli.command import aliases, CLIDependencies, all_commands
+from core.cli.model import CLIDependencies
+from core.cli.command import aliases, all_commands
 from core.db.db_access import DbAccess
 from core.dependencies import db_access, setup_process, parse_args
 from core.message_bus import MessageBus

--- a/ckcore/core/cli/__init__.py
+++ b/ckcore/core/cli/__init__.py
@@ -50,12 +50,11 @@ single_quoted_raw_string = single_quote_dp >> single_quoted_string_part_or_esc_d
 escaped_token = regex("\\\\[|\"';]").map(lambda x: x[1])
 # a command are tokens until EOF or pipe (all characters will be preserved)
 cmd_with_args_parser = (escaped_token | double_quoted_string | single_quoted_string | cmd_token).at_least(1).concat()
+
+# argument parser which will read the argument list while removing single and double quotes
 # command line arguments: foo "bla: 'foo = bla' -> [foo, bla, foo = bla]
-cmd_args_unquoted_parser = (
-    escaped_token
-    | (double_quote_dp >> double_quoted_string_part_or_esc_dp << double_quote_dp)
-    | (single_quote_dp >> single_quoted_string_part_or_esc_dp << single_quote_dp)
-    | any_non_white_space_string
+args_parts_unquoted_parser = (
+    escaped_token | double_quoted_raw_string | single_quoted_raw_string | any_non_white_space_string
 ).sep_by(space_dp)
 
 # argument parser which will read the argument list while removing single quotes

--- a/ckcore/core/cli/command.py
+++ b/ckcore/core/cli/command.py
@@ -34,7 +34,7 @@ from urllib.parse import urlparse, urlunparse
 
 import aiofiles
 import jq
-from aiohttp import ClientSession, TCPConnector, ClientTimeout, JsonPayload
+from aiohttp import ClientTimeout, JsonPayload
 from aiostream import stream
 from aiostream.aiter_utils import is_async_iterable
 from aiostream.core import Stream
@@ -48,7 +48,7 @@ from core.cli import (
     JsGen,
     NoExitArgumentParser,
     is_edge,
-    cmd_args_unquoted_parser,
+    args_parts_unquoted_parser,
     args_parts_parser,
 )
 from core.cli.model import (
@@ -66,7 +66,6 @@ from core.cli.model import (
     CLIDependencies,
     ParsedCommand,
 )
-from core.db.db_access import DbAccess
 from core.db.model import QueryModel
 from core.error import CLIParseError, ClientError, CLIExecutionError
 from core.model.graph_access import Section, EdgeType
@@ -2545,7 +2544,7 @@ class HttpCommand(CLICommand):
         arg_parser.add_argument("--timeout", dest="timeout", default=cls.default_timeout, type=parse_timeout)
         arg_parser.add_argument("--no-ssl-verify", dest="no_ssl_verify", default=False, action="store_true")
         arg_parser.add_argument("--no-body", dest="no_body", default=False, action="store_true")
-        args, remaining = arg_parser.parse_known_args(cmd_args_unquoted_parser.parse(arg.strip()) if arg else [])
+        args, remaining = arg_parser.parse_known_args(args_parts_unquoted_parser.parse(arg.strip()) if arg else [])
         if remaining:
             method, remaining = parse_method(remaining)
             parsed_url, remaining = parse_url(remaining)

--- a/ckcore/core/cli/command.py
+++ b/ckcore/core/cli/command.py
@@ -1624,11 +1624,15 @@ class ListCommand(CLICommand, OutputTransformer):
 
 class JobsCommand(CLICommand, PreserveOutputFormat):
     """
-    Usage: jobs
+    Usage: jobs [show|add|update|delete|activate|deactivate|run|ps] [name] [--schedule <cron_expression>]
+                [--wait-for-event <event_name>] [--timeout <duration_in_seconds>] [command_line]
+           jobs
            jobs show <name>
            jobs add <name> [--schedule <cron_expression>] [--wait-for-event <event_name>] <command_line>
            jobs update <name> [--schedule <cron_expression>] [--wait-for-event <event_name> :] <command_line>
            jobs delete <name>
+           jobs activate <name>
+           jobs deactivate <name>
            jobs run <name>
            jobs ps
 
@@ -1638,6 +1642,8 @@ class JobsCommand(CLICommand, PreserveOutputFormat):
     jobs add <name> ...: add a job to the task handler with provided name, trigger and command line to execute.
     jobs update <name> ... : update trigger and or command line of an existing job with provided name.
     jobs delete <name>: delete the job with the provided name.
+    jobs activate <name>: activate the triggers of a job.
+    jobs activate <name>: deactivate the triggers of a job - so the job will not get started.
     jobs run <name>: run the job as if the trigger would be triggered.
     jobs ps: show all currently running jobs.
 
@@ -1660,6 +1666,8 @@ class JobsCommand(CLICommand, PreserveOutputFormat):
         --wait-for-event <event_name> [optional]: if defined, the job waits for the specified event to occur.
                                       If this parameter is defined in combination with a schedule, the schedule has
                                       to trigger first, before the event will trigger the execution.
+        --timeout [optional, default=3600] Number of seconds, the job is allowed to run. In case this timeout is
+                                      exceeded, the job run will be killed.
         command_line [mandatory]:     the CLI command line that will be executed, when the job is triggered.
                                       Note: It is recommended to wrap the command line into single quotes or escape all
                                       CLI terms like pipe or semicolon (| -> \\|).

--- a/ckcore/core/cli/command.py
+++ b/ckcore/core/cli/command.py
@@ -1732,7 +1732,7 @@ class JobsCommand(CLICommand, PreserveOutputFormat):
         return "jobs"
 
     def info(self) -> str:
-        return "List all jobs in the system."
+        return "Manage all jobs."
 
     @staticmethod
     def is_jobs_update(command: ParsedCommand) -> bool:

--- a/ckcore/core/cli/model.py
+++ b/ckcore/core/cli/model.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import inspect
+from abc import ABC, abstractmethod
+from argparse import Namespace
+from asyncio import Queue, Task, iscoroutine
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, List, Any, Dict, Tuple, Callable, Union, Awaitable, Type, cast
+
+from aiostream import stream
+from aiostream.core import Stream
+
+from core.analytics import AnalyticsEventSender
+from core.cli import JsGen, T, Sink
+from core.db.db_access import DbAccess
+from core.error import CLIParseError
+from core.message_bus import MessageBus
+from core.model.model_handler import ModelHandler
+from core.query.model import Query
+from core.query.template_expander import TemplateExpander
+from core.task.job_handler import JobHandler
+from core.types import Json, JsonElement
+from core.worker_task_queue import WorkerTaskQueue
+
+
+class MediaType(Enum):
+    Json = 1
+    FilePath = 2
+
+    @property
+    def json(self) -> bool:
+        return self == MediaType.Json
+
+    @property
+    def file_path(self) -> bool:
+        return self == MediaType.FilePath
+
+    def __repr__(self) -> str:
+        return "application/json" if self == MediaType.Json else "application/octet-stream"
+
+
+@dataclass
+class CLIContext:
+    env: Dict[str, str] = field(default_factory=dict)
+    uploaded_files: Dict[str, str] = field(default_factory=dict)  # id -> path
+    query: Optional[Query] = None
+    query_options: Dict[str, Any] = field(default_factory=dict)
+
+
+EmptyContext = CLIContext()
+
+
+class CLIEngine(ABC):
+    @abstractmethod
+    async def evaluate_cli_command(
+        self, cli_input: str, context: CLIContext = EmptyContext, replace_place_holder: bool = True
+    ) -> List[ParsedCommandLine]:
+        pass
+
+
+class CLIDependencies:
+    def __init__(self, **deps: Any) -> None:
+        self.lookup: Dict[str, Any] = deps
+
+    def extend(self, **deps: Any) -> CLIDependencies:
+        self.lookup = {**self.lookup, **deps}
+        return self
+
+    @property
+    def args(self) -> Namespace:
+        return self.lookup["args"]  # type: ignore
+
+    @property
+    def message_bus(self) -> MessageBus:
+        return self.lookup["message_bus"]  # type:ignore
+
+    @property
+    def event_sender(self) -> AnalyticsEventSender:
+        return self.lookup["event_sender"]  # type:ignore
+
+    @property
+    def db_access(self) -> DbAccess:
+        return self.lookup["db_access"]  # type:ignore
+
+    @property
+    def model_handler(self) -> ModelHandler:
+        return self.lookup["model_handler"]  # type:ignore
+
+    @property
+    def job_handler(self) -> JobHandler:
+        return self.lookup["job_handler"]  # type:ignore
+
+    @property
+    def worker_task_queue(self) -> WorkerTaskQueue:
+        return self.lookup["worker_task_queue"]  # type:ignore
+
+    @property
+    def template_expander(self) -> TemplateExpander:
+        return self.lookup["template_expander"]  # type:ignore
+
+    @property
+    def forked_tasks(self) -> Queue[Tuple[Task[JsonElement], str]]:
+        return self.lookup["forked_tasks"]  # type:ignore
+
+    @property
+    def cli(self) -> CLIEngine:
+        return self.lookup["cli"]  # type:ignore
+
+
+@dataclass
+class CLICommandRequirement:
+    name: str
+
+
+@dataclass
+class CLIFileRequirement(CLICommandRequirement):
+    path: str  # local client path
+
+
+class CLIAction(ABC):
+    def __init__(self, produces: MediaType, requires: Optional[List[CLICommandRequirement]]) -> None:
+        self.produces = produces
+        self.required = requires if requires else []
+
+    @staticmethod
+    def make_stream(in_stream: JsGen) -> Stream:
+        return in_stream if isinstance(in_stream, Stream) else stream.iterate(in_stream)
+
+
+class CLISource(CLIAction):
+    def __init__(
+        self,
+        fn: Callable[[], Union[Tuple[Optional[int], JsGen], Awaitable[Tuple[Optional[int], JsGen]]]],
+        produces: MediaType = MediaType.Json,
+        requires: Optional[List[CLICommandRequirement]] = None,
+    ) -> None:
+        super().__init__(produces, requires)
+        self._fn = fn
+
+    async def source(self) -> Tuple[Optional[int], Stream]:
+        res = self._fn()
+        count, gen = await res if iscoroutine(res) else res
+        return count, self.make_stream(await gen if iscoroutine(gen) else gen)
+
+    @staticmethod
+    def with_count(
+        fn: Callable[[], Union[JsGen, Awaitable[JsGen]]],
+        count: Optional[int],
+        produces: MediaType = MediaType.Json,
+        requires: Optional[List[CLICommandRequirement]] = None,
+    ) -> CLISource:
+        async def combine() -> Tuple[Optional[int], JsGen]:
+            res = fn()
+            gen = await res if iscoroutine(res) else res
+            return count, gen
+
+        return CLISource(combine, produces, requires)
+
+    @staticmethod
+    def single(
+        fn: Callable[[], Union[JsGen, Awaitable[JsGen]]],
+        produces: MediaType = MediaType.Json,
+        requires: Optional[List[CLICommandRequirement]] = None,
+    ) -> CLISource:
+        return CLISource.with_count(fn, 1, produces, requires)
+
+    @staticmethod
+    def empty() -> CLISource:
+        return CLISource.with_count(stream.empty, 0)
+
+
+class CLIFlow(CLIAction):
+    def __init__(
+        self,
+        fn: Callable[[JsGen], Union[JsGen, Awaitable[JsGen]]],
+        produces: MediaType = MediaType.Json,
+        requires: Optional[List[CLICommandRequirement]] = None,
+    ) -> None:
+        super().__init__(produces, requires)
+        self._fn = fn
+
+    async def flow(self, in_stream: JsGen) -> Stream:
+        gen = self._fn(self.make_stream(in_stream))
+        return self.make_stream(await gen if iscoroutine(gen) else gen)
+
+
+class CLICommand(ABC):
+    """
+    The CLIPart is the base for all participants of the cli execution.
+    Source: generates a stream of objects
+    Flow: transforms the elements in a stream of objects
+    Sink: takes a stream of objects and creates a result
+    """
+
+    def __init__(self, dependencies: CLIDependencies):
+        self.dependencies = dependencies
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    def help(self) -> str:
+        # if not defined in subclass, fallback to inline doc
+        doc = inspect.getdoc(type(self))
+        return doc if doc else f"{self.name}: no help available."
+
+    @abstractmethod
+    def info(self) -> str:
+        pass
+
+    @abstractmethod
+    def parse(self, arg: Optional[str] = None, ctx: CLIContext = EmptyContext) -> CLIAction:
+        pass
+
+
+class InternalPart(ABC):
+    """
+    Internal parts can be executed but are not shown via help.
+    They usually get injected by the CLI Interpreter to ease usability.
+    """
+
+
+class OutputTransformer(ABC):
+    """
+    Mark all commands that transform the output stream (formatting).
+    """
+
+
+class PreserveOutputFormat(ABC):
+    """
+    Mark all commands where the output should not be flattened to default line output.
+    """
+
+
+@dataclass
+class ParsedCommand:
+    cmd: str
+    args: Optional[str] = None
+
+
+@dataclass
+class ParsedCommands:
+    commands: List[ParsedCommand]
+    env: Json = field(default_factory=dict)
+
+
+@dataclass
+class ExecutableCommand:
+    command: CLICommand
+    arg: Optional[str]
+    action: CLIAction
+
+
+@dataclass
+class ParsedCommandLine:
+    """
+    The parsed command line holds:
+    - ctx: the resulting environment coming from the parsed environment + the provided environment
+    - commands: all commands this command is defined from
+    - generator: this generator can be used in order to execute the command line
+    """
+
+    ctx: CLIContext
+    parsed_commands: ParsedCommands
+    executable_commands: List[ExecutableCommand]
+    unmet_requirements: List[CLICommandRequirement]
+
+    def __post_init__(self) -> None:
+        def expect_action(cmd: ExecutableCommand, expected: Type[T]) -> T:
+            action = cmd.action
+            if isinstance(action, expected):
+                return action
+            else:
+                message = "must be the first command" if issubclass(type(action), CLISource) else "no source data given"
+                raise CLIParseError(f"Command >{cmd.command.name}< can not be used in this position: {message}")
+
+        if self.executable_commands:
+            expect_action(self.executable_commands[0], CLISource)
+            for command in self.executable_commands[1:]:
+                expect_action(command, CLIFlow)
+
+    async def to_sink(self, sink: Sink[T]) -> T:
+        _, generator = await self.execute()
+        return await sink(generator)
+
+    @property
+    def commands(self) -> List[CLICommand]:
+        return [part.command for part in self.executable_commands]
+
+    @property
+    def produces(self) -> MediaType:
+        # the last command in the chain defines the resulting media type
+        return self.executable_commands[-1].action.produces if self.executable_commands else MediaType.Json
+
+    async def execute(self) -> Tuple[Optional[int], Stream]:
+        if self.executable_commands:
+            source_action = cast(CLISource, self.executable_commands[0].action)
+            count, flow = await source_action.source()
+            for command in self.executable_commands[1:]:
+                flow_action = cast(CLIFlow, command.action)
+                flow = await flow_action.flow(flow)
+            return count, flow
+        else:
+            return 0, stream.empty()

--- a/ckcore/core/parse_util.py
+++ b/ckcore/core/parse_util.py
@@ -120,6 +120,7 @@ double_quoted_string_part_or_esc_dp = (double_quoted_string_part_dp | string_esc
 double_quoted_string_dp = double_quote_dp >> double_quoted_string_part_or_esc_dp << double_quote_dp
 
 any_string = parsy.any_char.many().concat()
+any_non_white_space_string = parsy.test_char(lambda x: x != " ", "non whitespace").many().concat()
 double_quoted_or_simple_string_dp = double_quoted_string_dp | any_string
 any_non_whitespace_string = parsy.test_char(lambda c: c != " ", "non whitespace").at_least(1).concat()
 

--- a/ckcore/core/task/task_handler.py
+++ b/ckcore/core/task/task_handler.py
@@ -18,7 +18,7 @@ from aiostream import stream
 from core.analytics import AnalyticsEventSender, CoreEvent
 from core.cli import strip_quotes
 from core.cli.cli import CLI
-from core.cli.command import CLIContext
+from core.cli.model import CLIContext
 from core.db.jobdb import JobDb
 from core.db.runningtaskdb import RunningTaskData, RunningTaskDb
 from core.error import ParseError, CLIParseError
@@ -568,14 +568,14 @@ class TaskHandler(JobHandler):
                 wait = EventTrigger(event), wait_timeout
             await self.cli.evaluate_cli_command(command, ctx, replace_place_holder=False)
             uid = uuid_str(f"{command}{trigger}{wait}")[0:8]
-            return Job(uid, ExecuteCommand(command), trigger, timeout, wait, ctx.env, mutable)
+            return Job(uid, ExecuteCommand(command), timeout, trigger, wait, ctx.env, mutable)
 
         async def parse_event() -> Job:
             event, command = re.split("\\s*:\\s*", stripped, 1)
             command = strip_quotes(command, "'")
             await self.cli.evaluate_cli_command(command, ctx, replace_place_holder=False)
             uid = uuid_str(f"{command}{event}")[0:8]
-            return Job(uid, ExecuteCommand(command), EventTrigger(event), timeout, None, ctx.env, mutable)
+            return Job(uid, ExecuteCommand(command), timeout, EventTrigger(event), None, ctx.env, mutable)
 
         try:
             return await (parse_event() if self.event_re.match(stripped) else parse_with_cron())

--- a/ckcore/core/task/task_handler.py
+++ b/ckcore/core/task/task_handler.py
@@ -6,6 +6,7 @@ import logging
 import re
 from argparse import ArgumentParser, Namespace
 from asyncio import Task, CancelledError
+from contextlib import suppress
 from copy import copy
 from dataclasses import replace
 from datetime import timedelta
@@ -352,7 +353,8 @@ class TaskHandler(JobHandler):
         # mark step as error
         task.end()
         # remove from database
-        await self.running_task_db.delete(task.id)
+        with suppress(Exception):
+            await self.running_task_db.delete(task.id)
 
     async def delete_job(self, job_id: str) -> Optional[Job]:
         job: Job = first(lambda td: td.id == job_id and isinstance(td, Job), self.task_descriptions)  # type: ignore

--- a/ckcore/core/web/api.py
+++ b/ckcore/core/web/api.py
@@ -38,8 +38,9 @@ from networkx.readwrite import cytoscape_data
 
 from core import feature
 from core.analytics import AnalyticsEventSender
-from core.cli.cli import CLI, ParsedCommandLine
-from core.cli.command import CLIContext, OutputTransformer, ListCommand, PreserveOutputFormat
+from core.cli.cli import CLI
+from core.cli.model import ParsedCommandLine, CLIContext, OutputTransformer, PreserveOutputFormat
+from core.cli.command import ListCommand
 from core.config import ConfigEntity
 from core.db.db_access import DbAccess
 from core.db.model import QueryModel

--- a/ckcore/tests/core/cli/cli_test.py
+++ b/ckcore/tests/core/cli/cli_test.py
@@ -6,7 +6,9 @@ from pytest import fixture
 from typing import Tuple, List, AsyncIterator
 
 from core.analytics import InMemoryEventSender
-from core.cli.cli import CLI, multi_command_parser, ParsedCommands, ParsedCommand
+from core.cli.model import ParsedCommands, ParsedCommand
+from core.cli.cli import CLI, multi_command_parser
+from core.cli.model import CLIDependencies
 from core.cli.command import (
     ExecuteQueryCommand,
     ChunkCommand,
@@ -15,7 +17,6 @@ from core.cli.command import (
     EchoCommand,
     aliases,
     AggregateToCountCommand,
-    CLIDependencies,
     all_commands,
     PredecessorPart,
 )

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -19,15 +19,14 @@ from pytest import fixture
 
 from core.cli import is_node
 from core.cli.cli import CLI
-from core.cli.command import CLIDependencies, CLIContext, HttpCommand
+from core.cli.model import CLIDependencies, CLIContext, HttpCommand
 from core.db.jobdb import JobDb
 from core.error import CLIParseError
 from core.model.model import predefined_kinds
 from core.query.model import Template
-from core.task.task_description import TimeTrigger, Workflow
+from core.task.task_description import TimeTrigger, Workflow, EventTrigger
 from core.task.task_handler import TaskHandler
-from core.types import Json
-from core.util import first, exist, AccessJson
+from core.types import JsonElement
 
 # noinspection PyUnresolvedReferences
 from tests.core.analytics import event_sender
@@ -325,52 +324,78 @@ async def test_format(cli: CLI) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_job_command(cli: CLI, task_handler: TaskHandler, job_db: JobDb) -> None:
-    ctx = CLIContext(cli.cli_env)
-    result = await cli.execute_cli_command("add_job 23 1 * * * echo Hello World @NOW@", stream.list, ctx)
-    assert result == [["Job 06bf8ab1 added."]]
-    job = await job_db.get("06bf8ab1")
+async def test_jobs_command(cli: CLI, task_handler: TaskHandler, job_db: JobDb) -> None:
+    async def execute(cmd: str) -> List[List[JsonElement]]:
+        ctx = CLIContext(cli.cli_env)
+        return await cli.execute_cli_command(cmd, stream.list, ctx)
+
+    # add job with schedule
+    result = await execute('jobs add hello --schedule "23 1 * * *" echo Hello World @NOW@')
+    assert result == [["Job hello added."]]
+    job = await job_db.get("hello")
     assert job is not None
     assert job.command.command == "echo Hello World @NOW@"
     assert job.trigger == TimeTrigger("23 1 * * *")
     assert job.wait is None
     assert job in task_handler.task_descriptions
     assert job.environment == {"graph": "ns"}
-    with_event = await cli.execute_cli_command("add_job 23 1 * * * foo : echo Hello World", stream.list, ctx)
-    assert with_event == [["Job 2522f6d8 added."]]
-    job_with_event: Job = await job_db.get("2522f6d8")  # type: ignore
+
+    # add job with schedule and event
+    with_event = await execute('jobs add timed_hello --schedule "23 1 * * *" --wait-for-event foo  echo Hello World')
+    assert with_event == [["Job timed_hello added."]]
+    job_with_event: Job = await job_db.get("timed_hello")  # type: ignore
     assert job_with_event.wait is not None
     event_trigger, timeout = job_with_event.wait
     assert event_trigger.message_type == "foo"
-    assert timeout == timedelta(hours=24)
+    assert timeout == timedelta(hours=1)
     assert job_with_event.environment == {"graph": "ns"}
     assert job_with_event in task_handler.task_descriptions
-    only_event = await cli.execute_cli_command("add_job foo : echo Hello World", stream.list, ctx)
-    assert only_event == [["Job d11a8f65 added."]]
-    job_only_event: Job = await job_db.get("d11a8f65")  # type: ignore
+
+    # add job with event
+    only_event = await execute("jobs add only_event --wait-for-event foo echo Hello World")
+    assert only_event == [["Job only_event added."]]
+    job_only_event: Job = await job_db.get("only_event")  # type: ignore
+    assert job_only_event.trigger == EventTrigger("foo")
     assert job_only_event.wait is None
     assert job_only_event.environment == {"graph": "ns"}
     assert job_only_event in task_handler.task_descriptions
 
+    # add job without any trigger
+    no_trigger = await execute("jobs add no_trigger echo Hello World")
+    assert no_trigger == [["Job no_trigger added."]]
+    job_no_trigger: Job = await job_db.get("no_trigger")  # type: ignore
+    assert job_no_trigger.wait is None
+    assert job_no_trigger.environment == {"graph": "ns"}
+    assert job_no_trigger in task_handler.task_descriptions
 
-@pytest.mark.asyncio
-async def test_delete_job_command(cli: CLI, task_handler: TaskHandler, job_db: JobDb) -> None:
-    await cli.execute_cli_command("add_job 23 1 * * * echo Hello World", stream.list)
-    assert await job_db.get("0814c88f") is not None
-    result = await cli.execute_cli_command("delete_job 0814c88f", stream.list)
-    assert result == [["Job 0814c88f deleted."]]
-    assert await job_db.get("0814c88f") is None
-    assert not exist(lambda x: x.id == "0814c88f", task_handler.task_descriptions)  # type: ignore # pypy
+    # deactivate timed_hello
+    deactivated = await execute("jobs deactivate timed_hello")
+    assert deactivated[0][0]["active"] is False  # type: ignore
 
+    # activate timed_hello
+    activated = await execute("jobs activate timed_hello")
+    assert activated[0][0]["active"] is True  # type: ignore
 
-@pytest.mark.asyncio
-async def test_jobs_command(cli: CLI, task_handler: TaskHandler, job_db: JobDb) -> None:
-    await cli.execute_cli_command("add_job 23 1 * * * echo Hello World", stream.list)
-    result: List[Json] = (await cli.execute_cli_command("jobs", stream.list))[0]
-    job = first(lambda x: x.get("id") == "0814c88f", result)  # type: ignore # pypy
-    assert job is not None
-    assert job["trigger"] == {"cron_expression": "23 1 * * *"}
-    assert job["command"] == "echo Hello World"
+    # show specific job
+    no_trigger_show = await execute("jobs show no_trigger")
+    assert len(no_trigger_show[0]) == 1
+
+    # show all jobs
+    all_jobs = await execute("jobs")
+    assert len(all_jobs[0]) == 4
+
+    # start the job
+    run_hello = await execute("jobs run timed_hello")
+    assert run_hello[0][0].startswith("Job timed_hello started with id")  # type: ignore
+    assert [t for t in await task_handler.running_tasks() if t.descriptor.id == "timed_hello"]
+
+    # list all running jobs
+    all_running = await execute("jobs ps")
+    assert [r["job"] for r in all_running[0]] == ["timed_hello"]  # type: ignore
+
+    # delete a job
+    deleted = await execute("jobs delete timed_hello")
+    assert deleted == [["Job timed_hello deleted."]]
 
 
 @pytest.mark.asyncio
@@ -422,15 +447,6 @@ async def test_start_task_command(cli: CLI, task_handler: TaskHandler, test_work
     result = await cli.execute_cli_command(f"start_task {test_workflow.id}", stream.list)
     assert len(result[0]) == 1
     assert re.match("Task .+ has been started", result[0][0])
-
-
-@pytest.mark.asyncio
-async def test_tasks_command(cli: CLI, task_handler: TaskHandler, test_workflow: Workflow) -> None:
-    await task_handler.start_task(test_workflow, "direct")
-    result = await cli.execute_cli_command("tasks", stream.list)
-    assert len(result[0]) == 1
-    task = AccessJson(result[0][0])
-    assert task.descriptor.id == "test_workflow"
 
 
 @pytest.mark.asyncio

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -28,9 +28,10 @@ from core.query.model import Template
 from core.task.task_description import TimeTrigger, Workflow, EventTrigger
 from core.task.task_handler import TaskHandler
 from core.types import JsonElement, Json
+from core.util import AccessJson
 
 # noinspection PyUnresolvedReferences
-from core.util import AccessJson
+from tests.core.analytics import event_sender
 
 # noinspection PyUnresolvedReferences
 from tests.core.cli.cli_test import cli, cli_deps

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -19,17 +19,18 @@ from pytest import fixture
 
 from core.cli import is_node
 from core.cli.cli import CLI
-from core.cli.model import CLIDependencies, CLIContext, HttpCommand
+from core.cli.model import CLIDependencies, CLIContext
+from core.cli.command import HttpCommand
 from core.db.jobdb import JobDb
 from core.error import CLIParseError
 from core.model.model import predefined_kinds
 from core.query.model import Template
 from core.task.task_description import TimeTrigger, Workflow, EventTrigger
 from core.task.task_handler import TaskHandler
-from core.types import JsonElement
+from core.types import JsonElement, Json
 
 # noinspection PyUnresolvedReferences
-from tests.core.analytics import event_sender
+from core.util import AccessJson
 
 # noinspection PyUnresolvedReferences
 from tests.core.cli.cli_test import cli, cli_deps

--- a/ckcore/tests/core/db/jobdb_test.py
+++ b/ckcore/tests/core/db/jobdb_test.py
@@ -36,8 +36,8 @@ def event_db(job_db: JobDb, event_sender: InMemoryEventSender) -> EventJobDb:
 def jobs() -> List[Job]:
     wait = (EventTrigger("wait"), timedelta(seconds=30))
     return [
-        Job("id1", ExecuteCommand("echo hello"), EventTrigger("run_job"), timedelta(seconds=10)),
-        Job("id2", ExecuteCommand("sleep 10"), EventTrigger("run_job"), timedelta(seconds=10), wait),
+        Job("id1", ExecuteCommand("echo hello"), timedelta(seconds=10), EventTrigger("run_job")),
+        Job("id2", ExecuteCommand("sleep 10"), timedelta(seconds=10), EventTrigger("run_job"), wait),
     ]
 
 

--- a/ckcore/tests/core/task/task_description_test.py
+++ b/ckcore/tests/core/task/task_description_test.py
@@ -205,9 +205,9 @@ def test_marshalling_step() -> None:
 
 
 def test_marshalling_job() -> None:
-    j = Job("id", ExecuteCommand("echo hello"), EventTrigger("run_job"), timedelta(seconds=10))
+    j = Job("id", ExecuteCommand("echo hello"), timedelta(seconds=10), EventTrigger("run_job"))
     roundtrip(j)
-    roundtrip(Job(j.id, j.command, j.trigger, j.timeout, (EventTrigger("test"), timedelta(hours=2))))
+    roundtrip(Job(j.id, j.command, j.timeout, j.trigger, (EventTrigger("test"), timedelta(hours=2))))
 
 
 def test_marshalling_workflow(test_workflow: Workflow) -> None:

--- a/ckcore/tests/core/web/api_client.py
+++ b/ckcore/tests/core/web/api_client.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Set, Tuple
 from aiohttp import ClientSession
 from networkx import MultiDiGraph
 
-from core.cli.cli import ParsedCommands, ParsedCommand
+from core.cli.model import ParsedCommands, ParsedCommand
 from core.config import ConfigEntity
 from core.db import EstimatedQueryCost
 from core.db.model import GraphUpdate

--- a/cksh/README.md
+++ b/cksh/README.md
@@ -33,7 +33,7 @@ Cloudkeeper Shell
   --logfile LOGFILE     Logfile to log into
 ```
 
-ENV Prefix: `CKSH_`  
+ENV Prefix: `CKSH_`
 Every CLI arg can also be specified using ENV variables.
 
 For instance `--ckcore-uri http://foobar.tld:8900` would become `CKSH_CKCORE_URI=http://foobar.tld:8900`.
@@ -45,47 +45,53 @@ For instance `--ckcore-uri http://foobar.tld:8900` would become `CKSH_CKCORE_URI
 Enter `help` into `cksh` to get an overview of all available commands
 ```
 > help
+
+ckcore CLI
+
+
 Valid placeholder string:
-   @UTC@ -> 2021-09-28T16:08:32Z
-   @NOW@ -> 2021-09-28T16:08:32Z
-   @TODAY@ -> 2021-09-28
-   @TOMORROW@ -> 2021-09-29
-   @YESTERDAY@ -> 2021-09-27
-   @YEAR@ -> 2021
-   @MONTH@ -> 09
-   @DAY@ -> 28
-   @TIME@ -> 16:08:32
-   @HOUR@ -> 16
-   @MINUTE@ -> 08
-   @SECOND@ -> 32
-   @TZ_OFFSET@ -> +0000
-   @TZ@ -> UTC
-   @MONDAY@ -> 2021-10-04
-   @TUESDAY@ -> 2021-09-28
-   @WEDNESDAY@ -> 2021-09-29
-   @THURSDAY@ -> 2021-09-30
-   @FRIDAY@ -> 2021-10-01
-   @SATURDAY@ -> 2021-10-02
-   @SUNDAY@ -> 2021-10-03
+   @UTC@ -> 2022-01-12T09:20:02Z
+   @NOW@ -> 2022-01-12T10:20:02Z
+   @TODAY@ -> 2022-01-12
+   @TOMORROW@ -> 2022-01-13
+   @YESTERDAY@ -> 2022-01-11
+   @YEAR@ -> 2022
+   @MONTH@ -> 01
+   @DAY@ -> 12
+   @TIME@ -> 10:20:02
+   @HOUR@ -> 10
+   @MINUTE@ -> 20
+   @SECOND@ -> 02
+   @TZ_OFFSET@ -> +0100
+   @TZ@ -> CET
+   @MONDAY@ -> 2022-01-17
+   @TUESDAY@ -> 2022-01-18
+   @WEDNESDAY@ -> 2022-01-12
+   @THURSDAY@ -> 2022-01-13
+   @FRIDAY@ -> 2022-01-14
+   @SATURDAY@ -> 2022-01-15
+   @SUNDAY@ -> 2022-01-16
+
 Available Commands:
-   add_job - Add job to the system.
    aggregate - Aggregate this query by the provided specification
    ancestors - Select all ancestors of this node in the graph.
    chunk - Chunk incoming elements in batches.
    clean - Mark all incoming database objects for cleaning.
    count - Count incoming elements or sum defined property.
-   delete_job - Remove job from the system.
    descendants - Select all descendants of this node in the graph.
    desired - Matches a property in the desired section.
+   dump - Dump all properties of incoming objects.
    echo - Send the provided message to downstream
    env - Retrieve the environment and pass it to the output stream.
    flatten - Take incoming batches of elements and flattens them to a stream of single elements.
    format - Transform incoming objects as string with a defined format.
    head - Return n first elements of the stream.
    help - Shows available commands, as well as help for any specific command.
-   jobs - list all jobs in the system.
+   jobs - List all jobs in the system.
+   jq - Filter and process json.
    json - Parse json and pass parsed objects to the output stream.
    kind - Retrieves information about the graph data kinds.
+   list - Transform incoming objects as string with defined properties.
    merge_ancestors - Merge the results of this query with the content of ancestor nodes of given type
    metadata - Matches a property in the metadata section.
    predecessors - Select all predecessors of this node in the graph.
@@ -97,14 +103,18 @@ Available Commands:
    sleep - Suspend execution for an interval of time
    start_task - Start a task with the given name.
    successors - Select all successor of this node in the graph.
+   system - Access and manage system wide properties.
    tag - Update a tag with provided value or delete a tag
    tail - Return n last elements of the stream.
-   tasks - Lists all currently running tasks.
+   templates - Access the query template library.
    uniq - Remove all duplicated objects from the stream.
+   write - Writes the incoming stream of data to a file in the defined format.
+
 Available Aliases:
    match (reported) - Matches a property in the reported section.
    start_workflow (start_task) - Start a task with the given name.
    start_job (start_task) - Start a task with the given name.
+
 Note that you can pipe commands using the pipe character (|)
 and chain multiple commands using the semicolon (;).
 ```
@@ -113,20 +123,48 @@ Using `help` followed by a command will provide more information about that comm
 ```
 > help query
 query - Matches a property in all sections.
-Usage: query <property.path> <op> <value"
+
+Usage: query [--include-edges] [--explain] <property.path> <op> <value"
+
 Part of a query.
 With this command you can query all sections directly.
 In order to define the section, all parameters have to be prefixed by the section name.
+
 The property is the complete path in the json structure.
 Operation is one of: <=, >=, >, <, ==, !=, =~, !~, in, not in
 value is a json encoded value to match.
+
+Use --explain to understand the cost of a query. A query explanation has this form (example):
+{
+    "available_nr_items": 142670,
+    "estimated_cost": 61424,
+    "estimated_nr_items": 1,
+    "full_collection_scan": false,
+    "rating": "Simple"
+}
+
+- `available_nr_items` describe the number of all available nodes in the graph.
+- `estimated_cost` shows the absolute cost of this query. See rating for an interpreted number.
+- `estimated_nr_items` estimated number of items returned for this query.
+                       It is computed based on query statistics and heuristics and does not reflect the real number.
+- `full_collection_scan` indicates, if a full collection scan is required.
+                         In case this is true, the query does not take advantage of any indexes.
+- `rating` The more general rating of this query.
+           Simple: The estimated cost is fine - the query will most probably run smoothly.
+           Complex: The estimated cost is quite high. Check other properties. Maybe an index can be used?
+           Bad: The estimated cost is very high. It will most probably run long and/or will take a lot of resources.
+
+Parameter:
+    --include-edges: This flag indicates, that not only nodes should be returned, but also all related edges.
+    --explain: Instead of executing this query, explain the query cost
+
 Example:
     query reported.prop1 == "a"          # matches documents with reported section like { "prop1": "a" ....}
     query desired.some.nested in [1,2,3] # matches documents with desired section like { "some": { "nested" : 1 ..}
     query reported.array[*] == 2         # matches documents with reported section like { "array": [1, 2, 3] ... }
     query reported.array[1] == 2         # matches documents with reported section like { "array": [1, 2, 3] ... }
-Environment Variables:
-    graph [mandatory]: the name of the graph to operate on
+    query --include-edges is(graph_root) -[0:2]-> # returns the descendants from the graph root 2 levels deep
+    query --explain is(graph_root) -[0:2]->       # Shows the query cost of provided query
 ```
 
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -8,9 +8,9 @@ In this quick start guide, we’re showing you three things, how to:
 
     #. install Cloudkeeper for AWS with docker
     #. use the Cloudkeeper CLI to run your first ``collect`` process
-    #. query the results of the collect process 
+    #. query the results of the collect process
 
-The docker set-up takes 2-5 minutes. The duration of the first collect process depends on the size of your environment - usually 5-10 minutes. 
+The docker set-up takes 2-5 minutes. The duration of the first collect process depends on the size of your environment - usually 5-10 minutes.
 
 | Examples and data in this documentation are based on a small AWS `Cloud9 <https://aws.amazon.com/cloud9/>`_ environment.
 | To start exploring you need AWS credentials and a working Docker environment with access to AWS APIs.
@@ -118,7 +118,7 @@ How to access help
     @UTC@ -> 2021-09-25T19:11:19Z
     [...]
     Available Commands:
-    add_job - Add job to the system.
+    jobs - Manage all jobs.
     [...]
     Available Aliases:
     match (reported) - Matches a property in the reported section.
@@ -174,7 +174,7 @@ List your resource types
 
 See full list of currently `supported AWS ressources <https://github.com/someengineering/cloudkeeper/blob/main/plugins/aws/cloudkeeper_plugin_aws/resources.py>`_.
 
-We add new resources every week. Please star this `repo <http://github.com/someengineering/cloudkeeper>`_ to support us and stay up to date. If you’d like to request a specific resource, join our `Discord <https://discord.gg/someengineering>`_ channel and let us know!. 
+We add new resources every week. Please star this `repo <http://github.com/someengineering/cloudkeeper>`_ to support us and stay up to date. If you’d like to request a specific resource, join our `Discord <https://discord.gg/someengineering>`_ channel and let us know!.
 
 Query your resource types
 -------------------------
@@ -241,7 +241,7 @@ Both commands are identical, the 2nd one makes use of predefined placeholder str
 | ``help`` provides all available placeholder strings in section ``Valid placeholder string``
 | ``match`` automatically filters for the ``reported`` section of the response. With commands like ``query`` you need to explicitly select the reported section.  ``ctime`` is then selected via ``reported.ctime``.
 
-| ``count`` has another handy feature: building a sum over a provided parameter results. 
+| ``count`` has another handy feature: building a sum over a provided parameter results.
 | In this case: ``reported.instance_cores``.
 | This will sum the number of instance_cores for all ``aws_ec2_instances`` that were created before yesterday, groups them by reported.instance_cores results and counts the occurences of them.
 

--- a/docs/source/manual/automate.rst
+++ b/docs/source/manual/automate.rst
@@ -79,15 +79,15 @@ We can use the command line we have written above and turn it into a job:
 
 .. code-block:: bash
 
-    $> add_job post_collect: 'query is(resource) and reported.tags.owner==null | tag update owner "John Doe"'
-    Job bbbdcd24 added.
+    $> jobs add ensure-owner-tag --wait-for-event post_collect 'query is(resource) and reported.tags.owner==null | tag update owner "John Doe"'
+    Job ensure-owner-tag added.
 
 Let's revisit this line to understand what it does:
 
-- the query and tag command is the same that we used before. To not conflict with the `add_job` command line, the
-  job command line is wrapped in single quotes (if we would omit those, we would write: ``add_job ... | tag ...``
+- the query and tag command is the same that we used before. To not conflict with the `jobs` command line, the
+  job command line is wrapped in single quotes (if we would omit those, we would write: ``jobs add ... | tag ...``
   which is not what we want).
-- ``add_job`` is used to turn the command line into a job. A job is persisted in the database and will be available
+- ``jobs add`` is used to turn the command line into a job. A job is persisted in the database and will be available
   until it is deleted explicitly.
 - the job is triggered by the occurrence of the event `post_collect`. See :ref:`workflow-collect_and_cleanup` where
   this event is emitted by the default workflow after all resources have been collected. Since this workflow
@@ -103,15 +103,15 @@ since you will only see the result in the log stream.
     :caption: Further examples for job triggers
 
     # print hello world every minute to the log stream
-    $> add_job * * * * * echo hello world
+    $> jobs add say-hello --schedule '* * * * *' echo hello world
 
     # print a message when the post_collect event is received
-    $> add_job post_collect: echo collect is done!
+    $> jobs add on-collect-done --wait-for-event post_collect echo collect is done!
 
     # print a message when the first post_collect is received after 4 AM
     # Under the assumption that the post_collect event will come every hour,
     # this job would be only triggered once a day.
-    $> add_job 0 4 * * * post_collect: echo collect after 4AM is done!
+    $> jobs add early-message --schedule '0 4 * * *' --wait-for-event post_collect echo collect after 4AM is done!
 
 
 The job functionality can be used to automate actions. Here is a list of possible topics that
@@ -150,7 +150,7 @@ could be natural candidates for automation:
   hook a job into ``cleanup_plan``.
   Imagine you want to cleanup all compute instances in the load-testing account every Friday night, so they
   will not run over the weekend.
-  ``$> add_job 0 22 * * 5 cleanup_plan: 'query is(instance) and ancestors.account.reported.name==load-testing | clean'``
+  ``$> jobs add mark-resources-for-cleanup --schedule '0 22 * * 5' --wait-for-event cleanup_plan 'query is(instance) and ancestors.account.reported.name==load-testing | clean'``
 
 - Enforce tags structure
 

--- a/plugins/tagvalidator/README.md
+++ b/plugins/tagvalidator/README.md
@@ -8,7 +8,7 @@ on those instances is set to no more than 2 days. If it is set to e.g. 50h it wo
 
 This in combination with a cleanup job can be used to enforce such an expiration rule org wide.
 ```
-add_job cleanup_plan: query metadata.expires < "@NOW@" \| clean "Resource is expired"
+jobs add --wait-for-event cleanup_plan query metadata.expires < "@NOW@" \| clean "Resource is expired"
 ```
 
 ## Usage


### PR DESCRIPTION
Replace `add_job` `delete_job`, `tasks` with a more powerful `jobs` command

```
jobs: get the list of all jobs in the system
jobs show <name>: show the current definition of the job defined by given job name
jobs add <name> ...: add a job to the task handler with provided name, trigger and command line to execute.
jobs update <name> ... : update trigger and or command line of an existing job with provided name.
jobs delete <name>: delete the job with the provided name.
jobs activate <name>: activate the triggers of a job.
jobs deactivate <name>: deactivate the triggers of a job - so the job will not get started.
jobs run <name>: run the job as if the trigger would be triggered.
jobs ps: show all currently running jobs.
```

Fixes #517